### PR TITLE
Clarify one-time token file deletion

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -23,7 +23,7 @@ You can configure the KSM credentials via Spring Boot properties (e.g., in your 
 keeper.ksm.one-time-token = path/to/one-time-token.txt
 keeper.ksm.secret-path = path/to/ksm-config.json
 ```
-On the first run, the starter will read the token from the file, retrieve your KSM configuration and save it to the specified JSON file. The token file is deleted after use. **Note:** One-time tokens can only be used once; after the config file is created, remove the token file from your system.
+On the first run, the starter will read the token from the file and delete the file immediately, then redeem the token to retrieve your KSM configuration and save it to the specified JSON file. **Note:** One-time tokens can only be used once; after the config file is created, remove any leftover token files from your system.
 
 - **Option 2: Existing Config File** – If you already have a Keeper config JSON (e.g., from a previous initialization), you can just specify:
   ```properties

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
@@ -33,8 +33,8 @@ public class KeeperKsmProperties implements InitializingBean{
   /**
    * Path to a file containing a One-Time Access Token for Keeper Secrets Manager initialization.
    * <p>
-   * The starter will read the token from this file, redeem it to generate the configuration, and
-   * delete the file afterwards. Remove the token file once the config has been created.
+   * The starter reads the token from this file and deletes the file immediately before redeeming the token
+   * to generate the configuration. Remove any leftover token files once the config has been created.
    */
   private Path oneTimeToken;
 


### PR DESCRIPTION
## Summary
- mention that the token file is deleted before redeeming the token in the Spring Boot starter README
- keep Javadoc consistent with README

## Testing
- `./integration/spring-boot-starter-keeper-ksm/gradlew test --no-daemon` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_b_688b7d914fd0832fbc900c2a4749b65e