### PR TITLE
Add agent instructions and update JDK version

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/AGENTS.md
+++ b/integration/spring-boot-starter-keeper-ksm/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Instructions
+
+- Use JDK 21 for all Gradle commands.
+- After modifying any files in this directory, run `./gradlew test` from this directory and make sure it succeeds before committing.

--- a/integration/spring-boot-starter-keeper-ksm/SETUP.md
+++ b/integration/spring-boot-starter-keeper-ksm/SETUP.md
@@ -1,7 +1,7 @@
 # Setup Guide
 
 ## Prerequisites
-- JDK 24
+- JDK 21
 - Gradle 8 or later
 - Keeper Secrets Manager One-Time Token or existing config JSON
 

--- a/integration/spring-boot-starter-keeper-ksm/build.gradle
+++ b/integration/spring-boot-starter-keeper-ksm/build.gradle
@@ -8,9 +8,9 @@ group = 'com.keepersecurity'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(24)
-	}
+        toolchain {
+                languageVersion = JavaLanguageVersion.of(21)
+        }
     withSourcesJar()
     withJavadocJar()
 }


### PR DESCRIPTION
## Summary
- create AGENTS.md for spring-boot starter instructions
- switch starter build to JDK 21
- update docs to mention JDK 21

## Testing
- `./gradlew test` *(fails: Could not determine dependencies of task ':compileJava')*

------
https://chatgpt.com/codex/tasks/task_b_688b84371028832fa4b7ad613de25ada