### PR TITLE
Implement keystore storage for KSM config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ venv.bak/
 # Don't add Config files
 keeper.ini*
 *config*.json
+!integration/spring-boot-starter-keeper-ksm/src/test/resources/starter-ksm-config.json
 .secrets
 ansible.cfg
 

--- a/integration/spring-boot-starter-keeper-ksm/src/test/resources/starter-ksm-config.json
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/resources/starter-ksm-config.json
@@ -1,0 +1,9 @@
+{
+  "hostname": "localhost",
+  "serverPublicKeyId": "1",
+  "clientId": "client-id",
+  "clientKey": "client-key",
+  "appKey": "app-key",
+  "appOwnerPublicKey": "owner-public-key",
+  "privateKey": "private-key"
+}


### PR DESCRIPTION
## Summary
- add option to store redeemed KSM token config into a JCA keystore
- update auto configuration to choose between RAW and keystore providers
- provide minimal starter config fixture for tests
- allow fixture via `.gitignore`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_688bcbc0d2f4832fa24c596a892a415f