### PR TITLE
Expose Keeper secrets as Spring properties

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -104,6 +104,14 @@ signaling that they meet IL-5 security requirements.
   keeper.ksm.enforce-il5 = true
   ```
 
+- **Record Selection** – Specify which Keeper record UIDs should be loaded and
+  exposed as Spring configuration properties:
+  ```properties
+  keeper.ksm.records = Ue8h6JyWUs7Iu6eY_mha-w,abcd1234
+  ```
+  Once the starter is on the classpath, the fields from these records become
+  available using keys like `Ue8h6JyWUs7Iu6eY_mha-w.password`.
+
 ### Sun PKCS#11 Requirements
 
 Using the `SUN_PKCS11` provider requires the JDK's SunPKCS11 security provider

--- a/integration/spring-boot-starter-keeper-ksm/build.gradle
+++ b/integration/spring-boot-starter-keeper-ksm/build.gradle
@@ -53,6 +53,11 @@ dependencies {
     compileOnly 'com.oracle.oci.sdk:oci-java-sdk-keymanagement:3.60.0'
     compileOnly 'com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:3.60.0'
     compileOnly 'com.oracle.oci.sdk:oci-java-sdk-common:3.60.0'
+
+    // Only load Spring Cloud support if the application includes it
+    compileOnly 'org.springframework.cloud:spring-cloud-context:4.1.3'
+
+    testImplementation 'org.springframework.cloud:spring-cloud-context:4.1.3'
     
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
@@ -3,6 +3,7 @@ package com.keepersecurity.spring.ksm.autoconfig;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Provider;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -71,6 +72,12 @@ public class KeeperKsmProperties implements InitializingBean{
    */
   private boolean enforceIl5 = false;
 
+  /**
+   * Comma separated list of Keeper record UIDs to load and expose as
+   * configuration properties.
+   */
+  private List<String> records = List.of();
+
   // Getters and setters for the properties
   public Path getSecretPath() {
     return secretPath;
@@ -134,6 +141,14 @@ public class KeeperKsmProperties implements InitializingBean{
 
   public void setEnforceIl5(boolean enforceIl5) {
     this.enforceIl5 = enforceIl5;
+  }
+
+  public List<String> getRecords() {
+    return records;
+  }
+
+  public void setRecords(List<String> records) {
+    this.records = records;
   }
 
   @Override

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocator.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocator.java
@@ -1,0 +1,82 @@
+package com.keepersecurity.spring.ksm.config;
+
+import com.keepersecurity.secretsManager.core.KeeperRecord;
+import com.keepersecurity.secretsManager.core.KeeperRecordField;
+import com.keepersecurity.secretsManager.core.KeeperSecrets;
+import com.keepersecurity.secretsManager.core.Notation;
+import com.keepersecurity.secretsManager.core.SecretsManager;
+import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
+import com.keepersecurity.spring.ksm.autoconfig.KeeperKsmProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Loads Keeper Secrets Manager records and exposes them as Spring configuration
+ * properties.
+ */
+@ConditionalOnClass(SecretsManager.class)
+public class KsmPropertySourceLocator implements PropertySourceLocator {
+
+  private final SecretsManagerOptions options;
+  private final KeeperKsmProperties properties;
+
+  public KsmPropertySourceLocator(SecretsManagerOptions options, KeeperKsmProperties properties) {
+    this.options = options;
+    this.properties = properties;
+  }
+
+  @Override
+  public PropertySource<?> locate(Environment environment) {
+    List<String> recordIds = properties.getRecords();
+    if (recordIds == null || recordIds.isEmpty()) {
+      return null;
+    }
+    KeeperSecrets secrets = SecretsManager.getSecrets(options, recordIds);
+    Map<String, Object> flat = new HashMap<>();
+    for (KeeperRecord record : secrets.getRecords()) {
+      flattenRecord(record, flat);
+    }
+    return new MapPropertySource("keeperKsm", flat);
+  }
+
+  private void flattenRecord(KeeperRecord record, Map<String, Object> flat) {
+    String prefix = record.getRecordUid();
+    flat.put(prefix + ".title", record.getData().getTitle());
+    flat.put(prefix + ".type", record.getData().getType());
+    if (record.getData().getNotes() != null) {
+      flat.put(prefix + ".notes", record.getData().getNotes());
+    }
+    record.getData().getFields().forEach(f -> addField(prefix, f, flat));
+    if (record.getData().getCustom() != null) {
+      record.getData().getCustom().forEach(f -> addField(prefix, f, flat));
+    }
+  }
+
+  private void addField(String prefix, KeeperRecordField field, Map<String, Object> flat) {
+    String type = Notation.fieldType(field);
+    String label = field.getLabel();
+    String name = (label != null && !label.isBlank()) ? label : type;
+    String key = prefix + "." + name;
+    Object value = extractValue(field);
+    flat.put(key, value);
+  }
+
+  private Object extractValue(KeeperRecordField field) {
+    try {
+      Object val = field.getClass().getMethod("getValue").invoke(field);
+      if (val instanceof List<?> list) {
+        return list.stream().map(Object::toString).collect(Collectors.joining(","));
+      }
+      return val != null ? val.toString() : null;
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/integration/spring-boot-starter-keeper-ksm/src/main/resources/META-INF/spring/org.springframework.cloud.bootstrap.BootstrapConfiguration
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/resources/META-INF/spring/org.springframework.cloud.bootstrap.BootstrapConfiguration
@@ -1,0 +1,1 @@
+com.keepersecurity.spring.ksm.config.KsmPropertySourceLocator


### PR DESCRIPTION
## Summary
- add optional Spring Cloud dependency
- support `keeper.ksm.records` property
- implement `KsmPropertySourceLocator` to load secrets and flatten them into a property source
- register property source locator for Spring Boot
- document how to expose KSM secrets as configuration properties

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_688be1873380832f8653e34838658a22