### PR TITLE
Fix snapshot publishing for Spring Boot starter

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/build.gradle
+++ b/integration/spring-boot-starter-keeper-ksm/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
         toolchain {
-                languageVersion = JavaLanguageVersion.of(24)
+                languageVersion = JavaLanguageVersion.of(21)
         }
     withSourcesJar()
     withJavadocJar()
@@ -70,7 +70,7 @@ jar {
 publishing {
     repositories {
         maven {
-            name = "Keeper Central"
+            name = "KeeperCentral"
             credentials {
                 username = System.getenv("GH_REPO_USER")
                 password = System.getenv("GH_REPO_TOKEN")
@@ -84,7 +84,7 @@ publishing {
             from components.java
             groupId = 'com.keepersecurity'
             artifactId = 'spring-boot-starter-ksm'
-            version = '0.0.1-SNAPSHOT'
+            version = project.version
 
             pom {
                 name = 'Spring Boot Starter for Keeper Security'


### PR DESCRIPTION
## Summary
- use project version for Maven publication so snapshots publish correctly
- align Java toolchain with JDK 21 and fix repository name

## Testing
- `./gradlew test`
- `./gradlew clean build publish` *(fails: credentials.username not set)*

------
https://chatgpt.com/codex/tasks/task_b_6890bc325348832f9cba47e18733b7fa