### PR TITLE
Rename default config to ksm-config

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -46,10 +46,10 @@ The `keeper.ksm.container-type` property accepts the following values.  Options 
 
 | Value | Default location | Security level | Compliance profile | Notes |
 |-------|-----------------|----------------|--------------------|-------|
-| `default` | `kms-config.p12` | IL-2 | None | default Java keystore |
-| `named`   | `kms-config.p12` | IL-2 | None | named keystore entry |
-| `bc_fips` | `kms-config.bcfks` | IL-5 | FIPS 140-2 | requires Bouncy Castle FIPS |
-| `oracle_fips` | `kms-config.p12` | IL-5 | FIPS 140-2 | Oracle FIPS provider |
+| `default` | `ksm-config.p12` | IL-2 | None | default Java keystore |
+| `named`   | `ksm-config.p12` | IL-2 | None | named keystore entry |
+| `bc_fips` | `ksm-config.bcfks` | IL-5 | FIPS 140-2 | requires Bouncy Castle FIPS |
+| `oracle_fips` | `ksm-config.p12` | IL-5 | FIPS 140-2 | Oracle FIPS provider |
 | `sun_pkcs11` | `pkcs11://slot/0/token/kms` | IL-5 | FIPS 140-2 | Sun PKCS#11 provider |
 | `aws`     | `aws-secrets://region/resource` | IL-5 | FedRAMP High | *not implemented* |
 | `azure`   | `azure-keyvault://vault/resource` | IL-5 | FedRAMP High | *not implemented* |
@@ -57,7 +57,7 @@ The `keeper.ksm.container-type` property accepts the following values.  Options 
 | `azure_hsm` | `azure-dedicatedhsm://resource` | IL-5 | FedRAMP High | *not implemented* |
 | `google`  | `gcp-secretmanager://project/resource` | IL-4 | FedRAMP Moderate | *not implemented* |
 
-| `raw`     | `kms-config.json` | IL-2 | None | plain JSON file |
+| `raw`     | `ksm-config.json` | IL-2 | None | plain JSON file |
 | `hsm`     | `pkcs11://slot/0/token/kms` | IL-5 | FIPS 140-2 | PKCS#11 HSM |
 | `fortanix` | `fortanix://token` | IL-5 | FIPS 140-2 | Fortanix DSM |
 

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmConfigProvider.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmConfigProvider.java
@@ -9,13 +9,13 @@ package com.keepersecurity.spring.ksm.autoconfig;
  */
 public enum KsmConfigProvider {
     /** Default keystore using the platform provider. */
-    DEFAULT("kms-config.p12", SecurityLevel.IL2, SecurityProfile.NONE),
+    DEFAULT("ksm-config.p12", SecurityLevel.IL2, SecurityProfile.NONE),
     /** A named keystore entry using the platform provider. */
-    NAMED("kms-config.p12", SecurityLevel.IL2, SecurityProfile.NONE),
+    NAMED("ksm-config.p12", SecurityLevel.IL2, SecurityProfile.NONE),
     /** Keystore using the BouncyCastle FIPS provider. */
-    BC_FIPS("kms-config.bcfks", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
+    BC_FIPS("ksm-config.bcfks", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
     /** Keystore using the Oracle FIPS provider. */
-    ORACLE_FIPS("kms-config.p12", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
+    ORACLE_FIPS("ksm-config.p12", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
     /**
      * Uses the JVM's built-in SunPKCS11 provider.
      * <p>
@@ -40,7 +40,7 @@ public enum KsmConfigProvider {
     /** Configuration stored in a Fortanix DSM. */
     FORTANIX("fortanix://token", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
     /** Raw JSON configuration on the filesystem. */
-    RAW("kms-config.json", SecurityLevel.IL2, SecurityProfile.NONE),
+    RAW("ksm-config.json", SecurityLevel.IL2, SecurityProfile.NONE),
     /** Generic PKCS#11 HSM configuration. */
     HSM("pkcs11://slot/0/token/kms", SecurityLevel.IL5, SecurityProfile.FIPS_140_2);
 

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmKeystoreDefaults.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmKeystoreDefaults.java
@@ -44,9 +44,9 @@ public final class KsmKeystoreDefaults {
    * Provides the default keystore filename using the extension returned by
    * {@link #resolveDefaultExtension()}.
    *
-   * @return the default keystore file name
+  * @return the default keystore file name
    */
   public static String getDefaultKeystoreFilename() {
-      return "kms-config." + resolveDefaultExtension();
+      return "ksm-config." + resolveDefaultExtension();
   }
 }


### PR DESCRIPTION
## Summary
- rename default keystore filename to `ksm-config`
- update configuration provider defaults to use `ksm-config.*`
- document new default name in README

## Testing
- `cd integration/spring-boot-starter-keeper-ksm && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_6890c7b40760832f8c4240f6a5b41f6a