### PR TITLE
feat: throw exception after consuming KSM one-time token

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -23,7 +23,7 @@ You can configure the KSM credentials via Spring Boot properties (e.g., in your 
 keeper.ksm.one-time-token = path/to/one-time-token.txt
 keeper.ksm.secret-path = path/to/ksm-config.json
 ```
-On the first run, the starter reads the token from the file, redeems it to retrieve your KSM configuration and save it to the specified JSON file. The token file is deleted **after** the configuration is generated and the application then shuts down. **Note:** one-time tokens can only be used once; restart the application after removing the `keeper.ksm.one-time-token` property from your configuration.
+On the first run, the starter reads the token from the file, redeems it to retrieve your KSM configuration and save it to the specified JSON file. The token file is deleted **after** the configuration is generated and the starter throws a `OneTimeTokenConsumedException` to stop the application. **Note:** one-time tokens can only be used once; restart the application after removing the `keeper.ksm.one-time-token` property from your configuration.
 
 - **Option 2: Existing Config File** – If you already have a Keeper config JSON (e.g., from a previous initialization), you can just specify:
   ```properties

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
@@ -131,8 +131,9 @@ public class KeeperKsmAutoConfiguration {
       LOGGER.atWarn().setCause(e).log("Failed to delete one-time token file {}", tokenFile);
     }
 
-    LOGGER.atInfo().log("One-time token consumed. Remove the property 'keeper.ksm.one-time-token' and restart the application.");
-    System.exit(0);
+    String message = "One-time token consumed. Remove the property 'keeper.ksm.one-time-token' and restart the application.";
+    LOGGER.atInfo().log(message);
+    throw new OneTimeTokenConsumedException(message);
   }
 
   private void saveRawConfigToFile(ObjectNode config, KeeperKsmProperties props) {

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/OneTimeTokenConsumedException.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/OneTimeTokenConsumedException.java
@@ -1,0 +1,15 @@
+package com.keepersecurity.spring.ksm.autoconfig;
+
+/**
+ * Exception thrown after a one-time token has been consumed.
+ * <p>
+ * This signals that the application should terminate and remove the
+ * {@code keeper.ksm.one-time-token} property before restarting.
+ */
+public class OneTimeTokenConsumedException extends RuntimeException {
+
+    public OneTimeTokenConsumedException(String message) {
+        super(message);
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace `System.exit(0)` with `OneTimeTokenConsumedException`
- document new one-time token behaviour

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_6890cb86becc832fb8ade688575c9326