### PR TITLE
Use Keeper notation for property keys in starter

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocator.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocator.java
@@ -84,23 +84,24 @@ public class KsmPropertySourceLocator implements PropertySourceLocator {
   }
 
   private void flattenRecord(KeeperRecord record, Map<String, Object> flat) {
-    String prefix = record.getRecordUid();
-    flat.put(prefix + ".title", record.getData().getTitle());
-    flat.put(prefix + ".type", record.getData().getType());
+    String prefix = "keeper://" + record.getRecordUid();
+    flat.put(prefix + "/title", record.getData().getTitle());
+    flat.put(prefix + "/type", record.getData().getType());
     if (record.getData().getNotes() != null) {
-      flat.put(prefix + ".notes", record.getData().getNotes());
+      flat.put(prefix + "/notes", record.getData().getNotes());
     }
-    record.getData().getFields().forEach(f -> addField(prefix, f, flat));
+    record.getData().getFields().forEach(f -> addField(prefix, "field", f, flat));
     if (record.getData().getCustom() != null) {
-      record.getData().getCustom().forEach(f -> addField(prefix, f, flat));
+      record.getData().getCustom().forEach(f -> addField(prefix, "custom_field", f, flat));
     }
   }
 
-  private void addField(String prefix, KeeperRecordField field, Map<String, Object> flat) {
+  private void addField(
+      String prefix, String selector, KeeperRecordField field, Map<String, Object> flat) {
     String type = Notation.fieldType(field);
     String label = field.getLabel();
     String name = (label != null && !label.isBlank()) ? label : type;
-    String key = prefix + "." + name;
+    String key = prefix + "/" + selector + "/" + name;
     Object value = extractValue(field);
     flat.put(key, value);
   }

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocatorTest.java
@@ -48,8 +48,8 @@ class KsmPropertySourceLocatorTest {
             KsmPropertySourceLocator locator = new KsmPropertySourceLocator(options, props);
             PropertySource<?> ps = locator.locate(new MockEnvironment());
 
-            assertEquals("my-secret", ps.getProperty(recordUid + ".password"));
-            assertEquals("Test Record", ps.getProperty(recordUid + ".title"));
+            assertEquals("my-secret", ps.getProperty("keeper://" + recordUid + "/field/password"));
+            assertEquals("Test Record", ps.getProperty("keeper://" + recordUid + "/title"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose Keeper record metadata under `keeper://<UID>/<title|type|notes>` keys
- expose standard and custom fields using Keeper notation selectors
- adjust tests to verify notation-based property keys

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_6890d7c1c6d4832f8f58dc0ff1b4bbfd