### PR TITLE
Add Thymeleaf UI for KSM Spring Boot example

### DIFF
--- a/examples/spring-boot/README.md
+++ b/examples/spring-boot/README.md
@@ -3,27 +3,45 @@
 This sample demonstrates how to use the `spring-boot-starter-keeper-ksm` starter
 in a minimal Spring Boot application.
 
-## Prerequisites
+## Keeper Spring Boot Example
+
+This example demonstrates fetching KSM secrets using a Thymeleaf frontend.
+
+### Prerequisites
 
 - Java 21
 - Gradle
-- A Keeper Secrets Manager configuration file generated from a one-time token.
+- You must have a valid Keeper KSM config file stored at:
+  `~/.keeper/ksm-config.json`
+  - You can generate one using:
+    `keeper shell ksm profile init --app-owner`
+  - Or follow the Keeper KSM docs:
+    https://docs.keeper.io/secrets-manager/
 
-## Build and Run
+Edit `src/main/resources/application.yaml` to enable config loading:
 
-To run the application:
+```yaml
+ksm:
+  config:
+    path: ~/.keeper/ksm-config.json
+    useRawJson: true
+```
+
+### Start the example
+
+From `/examples/spring-boot`, run:
 
 ```bash
 ./gradlew bootRun
 ```
 
-The `application.yaml` file configures where the starter should look for your
-Keeper Secrets Manager configuration and which records to load:
+Then open <http://localhost:8080> in your browser.
 
-```yaml
-keeper:
-  ksm:
-    secret-path: path/to/ksm-config.json
-    records:
-      - RECORD_UID
-```
+🔎 **Use the UI**
+
+Paste a Keeper Notation string (e.g. `keeper://ABC123/field/password`)
+
+Click "Fetch Secret"
+
+The fetched value will appear, along with a list of Spring configuration
+properties populated from KSM.

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -27,6 +27,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'com.keepersecurity:spring-boot-starter-keeper-ksm:0.0.1-SNAPSHOT'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/examples/spring-boot/src/main/java/com/example/SecretController.java
+++ b/examples/spring-boot/src/main/java/com/example/SecretController.java
@@ -1,0 +1,32 @@
+package com.example;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class SecretController {
+
+    private final SecretService secretService;
+
+    public SecretController(SecretService secretService) {
+        this.secretService = secretService;
+    }
+
+    @GetMapping("/")
+    public String index(Model model) {
+        model.addAttribute("secret", null);
+        model.addAttribute("configMap", secretService.getSpringConfig());
+        return "index";
+    }
+
+    @PostMapping("/")
+    public String fetch(@RequestParam("notation") String notation, Model model) {
+        String secret = secretService.fetchSecret(notation);
+        model.addAttribute("secret", secret);
+        model.addAttribute("configMap", secretService.getSpringConfig());
+        return "index";
+    }
+}

--- a/examples/spring-boot/src/main/java/com/example/SecretService.java
+++ b/examples/spring-boot/src/main/java/com/example/SecretService.java
@@ -1,0 +1,53 @@
+package com.example;
+
+import com.keepersecurity.secretsManager.core.SecretsManager;
+import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class SecretService {
+
+    private final SecretsManagerOptions options;
+    private final Environment environment;
+
+    public SecretService(SecretsManagerOptions options, Environment environment) {
+        this.options = options;
+        this.environment = environment;
+    }
+
+    public String fetchSecret(String keeperNotation) {
+        if (keeperNotation == null || keeperNotation.isBlank()) {
+            return null;
+        }
+        try {
+            List<String> results = SecretsManager.getNotationResults(options, keeperNotation);
+            return results.isEmpty() ? null : results.get(0);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public Map<String, Object> getSpringConfig() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        if (environment instanceof ConfigurableEnvironment configurableEnvironment) {
+            MutablePropertySources propertySources = configurableEnvironment.getPropertySources();
+            for (PropertySource<?> propertySource : propertySources) {
+                if (propertySource instanceof EnumerablePropertySource<?> enumerable) {
+                    for (String name : enumerable.getPropertyNames()) {
+                        props.put(name, enumerable.getProperty(name));
+                    }
+                }
+            }
+        }
+        return props;
+    }
+}

--- a/examples/spring-boot/src/main/resources/application.yaml
+++ b/examples/spring-boot/src/main/resources/application.yaml
@@ -1,6 +1,4 @@
-keeper:
-  ksm:
-    secret-path: path/to/ksm-config.json
-    # List of record UIDs to load as configuration properties
-    records:
-      - RECORD_UID
+ksm:
+  config:
+    path: ~/.keeper/ksm-config.json
+    useRawJson: true

--- a/examples/spring-boot/src/main/resources/templates/index.html
+++ b/examples/spring-boot/src/main/resources/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Keeper Secret Fetcher</title>
+</head>
+<body>
+<h1>Keeper Secret Fetcher</h1>
+<form th:action="@{/}" method="post">
+    <input type="text" name="notation" placeholder="keeper://UID/field/password" />
+    <button type="submit">Fetch Secret</button>
+</form>
+<div>
+    <h2>Secret</h2>
+    <p th:text="${secret}"></p>
+</div>
+<div>
+    <h2>Configuration</h2>
+    <ul>
+        <li th:each="entry : ${#maps.entries(configMap)}">
+            <span th:text="${entry.key}"></span>: <span th:text="${entry.value}"></span>
+        </li>
+    </ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate Thymeleaf starter and template for fetching secrets
- expose SecretService and SecretController to handle notation queries
- document Keeper config and usage instructions

## Testing
- `./gradlew test` *(fails: Username must not be null)*
- `./gradlew bootRun` *(fails: Username must not be null)*

------
https://chatgpt.com/codex/tasks/task_b_6890e8144b7c832f985780787427ccbd