### PR TITLE
Fix Spring Boot example for raw KSM configuration

### DIFF
--- a/examples/spring-boot/README.md
+++ b/examples/spring-boot/README.md
@@ -21,10 +21,10 @@ This example demonstrates fetching KSM secrets using a Thymeleaf frontend.
 Edit `src/main/resources/application.yaml` to enable config loading:
 
 ```yaml
-ksm:
-  config:
-    path: ~/.keeper/ksm-config.json
-    useRawJson: true
+keeper:
+  ksm:
+    container-type: raw
+    secret-path: ~/.keeper/ksm-config.json
 ```
 
 ### Start the example

--- a/examples/spring-boot/src/main/resources/application.yaml
+++ b/examples/spring-boot/src/main/resources/application.yaml
@@ -1,4 +1,4 @@
-ksm:
-  config:
-    path: ~/.keeper/ksm-config.json
-    useRawJson: true
+keeper:
+  ksm:
+    container-type: raw
+    secret-path: ~/.keeper/ksm-config.json


### PR DESCRIPTION
## Summary
- configure Spring Boot sample to load raw KSM config using `container-type: raw` and `secret-path`
- update README to document new `keeper.ksm` properties

## Testing
- `./gradlew test` *(fails: Could not resolve com.keepersecurity:spring-boot-starter-keeper-ksm:0.0.1-SNAPSHOT - Username must not be null!)*

------
https://chatgpt.com/codex/tasks/task_b_6890f48a1080832fabbd7d7f0f080966