### PR TITLE
Add SoftHSM2 provider with PKCS#11 library auto-detection

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
@@ -52,7 +52,7 @@ public class KeeperKsmProperties implements InitializingBean{
    * Type of secret container to use. Supported values correspond to the
    * constants in {@link KsmConfigProvider} such as
    * {@code default}, {@code named}, {@code bc_fips},
-   * {@code oracle_fips}, {@code sun_pkcs11}, {@code aws},
+   * {@code oracle_fips}, {@code sun_pkcs11}, {@code softhsm2}, {@code aws},
    * {@code azure}, {@code aws_hsm}, {@code azure_hsm},
    * {@code google}, {@code fortanix}, {@code raw}, {@code hsm}.
    * For raw JSON configuration, use {@link KsmConfigProvider#RAW}.

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/PKCS11Config.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/PKCS11Config.java
@@ -1,0 +1,27 @@
+package com.keepersecurity.spring.ksm.autoconfig;
+
+/**
+ * Simple representation of a PKCS#11 configuration describing the path to the native library.
+ */
+public class PKCS11Config {
+
+    private final String libraryPath;
+
+    /**
+     * Creates a new configuration instance.
+     *
+     * @param libraryPath path to the native PKCS#11 library
+     */
+    public PKCS11Config(String libraryPath) {
+        this.libraryPath = libraryPath;
+    }
+
+    /**
+     * Returns the path to the PKCS#11 library.
+     *
+     * @return library path as a string
+     */
+    public String getLibraryPath() {
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
## Summary
- add SoftHSM2 config provider with automatic PKCS#11 library detection
- block SoftHSM2 when IL5 enforcement is enabled
- expose simple PKCS11Config factory and helper

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_6891140bcf00832fbe0fabc1a09577f1