### PR TITLE
Add configurable HSM provider support

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -34,6 +34,7 @@ On the first run, the starter reads the token from the file, redeems it to retri
 - **Secret Container Options** – The config can be stored in different container types. By default a local file is used. Set the container type and optional credentials if needed:
   ```properties
   keeper.ksm.container-type = pkcs11
+  keeper.ksm.hsm-provider = softHsm2
   keeper.ksm.pkcs11-library = /path/to/lib.so
   keeper.ksm.secret-user = changeme
   keeper.ksm.secret-password = changeme

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/HsmProvider.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/HsmProvider.java
@@ -1,0 +1,12 @@
+package com.keepersecurity.spring.ksm.autoconfig;
+
+/**
+ * Known hardware security module providers supported by the starter.
+ */
+public enum HsmProvider {
+    /** Local development SoftHSM2 implementation. */
+    SOFT_HSM2,
+    /** JVM built-in SunPKCS11 provider. */
+    SUN_PKCS11
+}
+

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
@@ -80,6 +80,15 @@ public class KeeperKsmAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean // Only create the bean if one isn't already defined in the context
   SecretsManagerOptions secretsManagerOptions(KeeperKsmProperties properties) {
+    if (properties.getHsmProvider() == HsmProvider.SOFT_HSM2) {
+      if (properties.isEnforceIl5()) {
+        String message = "SoftHSM2 is not IL-5 compliant";
+        LOGGER.atError().log(message);
+        throw new IllegalStateException(message);
+      }
+      PKCS11Config pkcs11 = KsmConfigProvider.SOFTHSM2.createPkcs11Config(properties);
+      properties.setPkcs11Library(pkcs11.getLibraryPath());
+    }
     Optional<Path> tokenPath = Optional.ofNullable(properties.getOneTimeToken());
     tokenPath.ifPresent(path -> {
       String token;

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
@@ -76,6 +76,16 @@ public class KeeperKsmProperties implements InitializingBean{
   private String pkcs11Library;
 
   /**
+   * Known HSM provider to assist with PKCS#11 configuration. Optional.
+   * <p>
+   * When set to {@link HsmProvider#SOFT_HSM2}, the starter will attempt to
+   * auto-detect the SoftHSM2 library path. {@link HsmProvider#SUN_PKCS11}
+   * indicates that the JDK's built in SunPKCS11 provider is used.
+   * </p>
+   */
+  private HsmProvider hsmProvider;
+
+  /**
    * When true, the application will fail to start unless the IL-5 certified provider is
    * available. This can be used to enforce IL-5 compliance.
    */
@@ -218,6 +228,24 @@ public class KeeperKsmProperties implements InitializingBean{
   }
 
   /**
+   * Returns the configured HSM provider, if any.
+   *
+   * @return the selected {@link HsmProvider} or {@code null}
+   */
+  public HsmProvider getHsmProvider() {
+    return hsmProvider;
+  }
+
+  /**
+   * Sets the HSM provider to use for PKCS#11 operations.
+   *
+   * @param hsmProvider provider identifier
+   */
+  public void setHsmProvider(HsmProvider hsmProvider) {
+    this.hsmProvider = hsmProvider;
+  }
+
+  /**
    * Whether the application should enforce IL‑5 readiness.
    *
    * @return {@code true} if IL‑5 enforcement is enabled
@@ -261,6 +289,9 @@ public class KeeperKsmProperties implements InitializingBean{
   public void afterPropertiesSet() throws Exception {
     if (enforceIl5 && !providerType.isIl5Ready()) {
       notIl5Compliant(providerType);
+    }
+    if (enforceIl5 && hsmProvider == HsmProvider.SOFT_HSM2) {
+      notIl5Compliant(KsmConfigProvider.SOFTHSM2);
     }
     if (secretPath == null) {
       secretPath = Paths.get(providerType.getDefaultLocation());

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
@@ -17,4 +17,13 @@ class Il5EnforcementTest {
                         "keeper.ksm.enforce-il5=true")
                 .run(context -> org.assertj.core.api.Assertions.assertThat(context).hasFailed());
     }
+
+    @Test
+    void softHsm2NotAllowedWithIl5Enforcement() {
+        contextRunner
+                .withPropertyValues(
+                        "keeper.ksm.enforce-il5=true",
+                        "keeper.ksm.hsm-provider=softHsm2")
+                .run(context -> org.assertj.core.api.Assertions.assertThat(context).hasFailed());
+    }
 }


### PR DESCRIPTION
## Summary
- add `HsmProvider` enum and expose `hsm-provider` property in `KeeperKsmProperties`
- create PKCS11 config for SoftHSM2 and block it when IL5 is enforced
- document new option and extend IL5 enforcement test

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_689119b405b8832f86fe50048fe6f284