### PR TITLE
Expand SoftHSM2 library detection

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/HOW_TO/SOFTHSM2.md
+++ b/integration/spring-boot-starter-keeper-ksm/HOW_TO/SOFTHSM2.md
@@ -20,9 +20,9 @@ softhsm2-util --init-token --slot 0 --label ksm-token
 
 ## Configure the provider
 1. Ensure the `SOFTHSM2_CONF` environment variable points to your configuration file if you are not using the default location.
-2. Configure the Spring Boot starter to use the PKCS#11 library:
+2. Configure the Spring Boot starter to use the PKCS#11 library. Depending on your installation, the library may reside in `/usr/lib/softhsm` or `/usr/local/lib/softhsm`:
    ```yaml
-   keeper.ksm.pkcs11.library: /usr/lib/softhsm/libsofthsm2.so
+   keeper.ksm.pkcs11.library: /usr/lib/softhsm/libsofthsm2.so # or /usr/local/lib/softhsm/libsofthsm2.so
    ```
 3. Start the application and enter the PIN when prompted.
 

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmConfigProvider.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmConfigProvider.java
@@ -207,12 +207,16 @@ public enum KsmConfigProvider {
         if (Files.isReadable(macOs)) {
             return macOs;
         }
-        Path linux = Paths.get("/usr/local/lib/softhsm/libsofthsm2.so");
-        if (Files.isReadable(linux)) {
-            return linux;
+        Path linuxUsr = Paths.get("/usr/lib/softhsm/libsofthsm2.so");
+        if (Files.isReadable(linuxUsr)) {
+            return linuxUsr;
+        }
+        Path linuxUsrLocal = Paths.get("/usr/local/lib/softhsm/libsofthsm2.so");
+        if (Files.isReadable(linuxUsrLocal)) {
+            return linuxUsrLocal;
         }
         throw new IllegalStateException(
-            "SoftHSM2 PKCS#11 library not found or unreadable at /opt/homebrew/lib/softhsm/libsofthsm2.so or /usr/local/lib/softhsm/libsofthsm2.so");
+            "SoftHSM2 PKCS#11 library not found or unreadable at /opt/homebrew/lib/softhsm/libsofthsm2.so, /usr/lib/softhsm/libsofthsm2.so, or /usr/local/lib/softhsm/libsofthsm2.so");
     }
 }
 


### PR DESCRIPTION
## Summary
- broaden SoftHSM2 PKCS#11 library detection to include `/usr/lib/softhsm/libsofthsm2.so`
- document alternate SoftHSM2 library locations

## Testing
- `cd integration/spring-boot-starter-keeper-ksm && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_6891223b80a4832fb2cdcec2a1f94db1