### PR TITLE
Validate FIPS compliance for HSM providers

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/HsmProvider.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/HsmProvider.java
@@ -4,9 +4,28 @@ package com.keepersecurity.spring.ksm.autoconfig;
  * Known hardware security module providers supported by the starter.
  */
 public enum HsmProvider {
-    /** Local development SoftHSM2 implementation. */
-    SOFT_HSM2,
-    /** JVM built-in SunPKCS11 provider. */
-    SUN_PKCS11
+  /** Local development SoftHSM2 implementation. */
+  SOFT_HSM2(false),
+  /** JVM built-in SunPKCS11 provider. */
+  SUN_PKCS11(true),
+  /** Bouncy Castle FIPS-approved provider. */
+  BOUNCYCASTLE_FIPS(true),
+  /** AWS CloudHSM FIPS-approved provider. */
+  AWS_CLOUDHSM(true);
+
+  private final boolean fipsApproved;
+
+  HsmProvider(boolean fipsApproved) {
+    this.fipsApproved = fipsApproved;
+  }
+
+  /**
+   * Indicates whether this provider is FIPS 140-2 approved.
+   *
+   * @return {@code true} if FIPS approved
+   */
+  public boolean isFipsApproved() {
+    return fipsApproved;
+  }
 }
 

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
@@ -287,14 +287,22 @@ public class KeeperKsmProperties implements InitializingBean{
    * where necessary.
    */
   public void afterPropertiesSet() throws Exception {
-    if (enforceIl5 && !providerType.isIl5Ready()) {
-      notIl5Compliant(providerType);
-    }
-    if (enforceIl5 && hsmProvider == HsmProvider.SOFT_HSM2) {
-      notIl5Compliant(KsmConfigProvider.SOFTHSM2);
+    if (enforceIl5) {
+      validateHsmProvider();
+      if (!providerType.isIl5Ready()) {
+        notIl5Compliant(providerType);
+      }
     }
     if (secretPath == null) {
       secretPath = Paths.get(providerType.getDefaultLocation());
+    }
+  }
+
+  private void validateHsmProvider() {
+    if (hsmProvider == null || !hsmProvider.isFipsApproved()) {
+      String message = "Configured HSM provider is not FIPS-approved. IL5 enforcement requires a FIPS-compliant PKCS#11 provider.";
+      LOGGER.atError().log(message);
+      throw new IllegalStateException(message);
     }
   }
 

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
@@ -10,11 +10,11 @@ class Il5EnforcementTest {
             .withPropertyValues("keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json");
 
     @Test
-    void failsWithoutFipsProviderWhenIl5Enforced() {
+    void failsWithoutHsmProviderWhenIl5Enforced() {
         contextRunner
                 .withPropertyValues(
-                        "keeper.ksm.provider=org.bouncycastle.jce.provider.BouncyCastleProvider",
-                        "keeper.ksm.enforce-il5=true")
+                        "keeper.ksm.enforce-il5=true",
+                        "keeper.ksm.container-type=sun_pkcs11")
                 .run(context -> org.assertj.core.api.Assertions.assertThat(context).hasFailed());
     }
 
@@ -23,7 +23,18 @@ class Il5EnforcementTest {
         contextRunner
                 .withPropertyValues(
                         "keeper.ksm.enforce-il5=true",
+                        "keeper.ksm.container-type=sun_pkcs11",
                         "keeper.ksm.hsm-provider=softHsm2")
                 .run(context -> org.assertj.core.api.Assertions.assertThat(context).hasFailed());
+    }
+
+    @Test
+    void awsCloudHsmAllowedWithIl5Enforcement() {
+        contextRunner
+                .withPropertyValues(
+                        "keeper.ksm.enforce-il5=true",
+                        "keeper.ksm.container-type=sun_pkcs11",
+                        "keeper.ksm.hsm-provider=awsCloudHsm")
+                .run(context -> org.assertj.core.api.Assertions.assertThat(context).hasNotFailed());
     }
 }


### PR DESCRIPTION
## Summary
- ensure IL5 enforcement only allows FIPS-approved HSM providers
- expand HsmProvider enum with FIPS approval metadata
- add tests for HSM provider compliance

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_6891253bcc8c832f8d5982cb30da38cc