### PR TITLE
Add IL5 crypto provider validation

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidator.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidator.java
@@ -1,0 +1,46 @@
+package com.keepersecurity.spring.ksm.autoconfig;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.env.Environment;
+
+/**
+ * Validates that a FIPS-certified crypto provider is active when IL5 enforcement is enabled.
+ */
+class Il5ComplianceValidator implements InitializingBean {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Il5ComplianceValidator.class);
+
+  private final KeeperKsmProperties properties;
+  private final Environment environment;
+
+  Il5ComplianceValidator(KeeperKsmProperties properties, Environment environment) {
+    this.properties = properties;
+    this.environment = environment;
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    if (!properties.isEnforceIl5()) {
+      return;
+    }
+    boolean fipsPresent = Arrays.stream(Security.getProviders())
+        .map(Provider::getName)
+        .map(String::toUpperCase)
+        .anyMatch(name -> name.contains("FIPS"));
+    if (!fipsPresent) {
+      String message = "No FIPS-certified crypto provider (e.g. BCFIPS) is active. IL5 mode requires FIPS-compliant crypto.";
+      if ("warn".equalsIgnoreCase(environment.getProperty("crypto.check.mode"))) {
+        LOGGER.atWarn().log(message);
+      } else {
+        LOGGER.atError().log(message);
+        throw new IllegalStateException(message);
+      }
+    }
+  }
+}
+

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.keepersecurity.secretsManager.core.InMemoryStorage;
@@ -113,6 +114,11 @@ public class KeeperKsmAutoConfiguration {
     });
     KeyValueStorage storage = new InMemoryStorage(getKmsConfig(properties));
     return new SecretsManagerOptions(storage);
+  }
+
+  @Bean
+  Il5ComplianceValidator il5ComplianceValidator(KeeperKsmProperties properties, Environment environment) {
+    return new Il5ComplianceValidator(properties, environment);
   }
 
   private String getKmsConfig(KeeperKsmProperties properties) {

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
@@ -1,0 +1,53 @@
+package com.keepersecurity.spring.ksm.autoconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.Provider;
+import java.security.Security;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class Il5ComplianceValidatorTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(KeeperKsmAutoConfiguration.class)
+            .withPropertyValues(
+                    "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
+                    "keeper.ksm.container-type=sun_pkcs11",
+                    "keeper.ksm.hsm-provider=awsCloudHsm");
+
+    @Test
+    void failsWithoutFipsProviderWhenIl5Enforced() {
+        contextRunner
+                .withPropertyValues("keeper.ksm.enforce-il5=true")
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    @Test
+    void warnsInsteadOfFailingWhenModeWarn() {
+        contextRunner
+                .withPropertyValues(
+                        "keeper.ksm.enforce-il5=true",
+                        "crypto.check.mode=warn")
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    void passesWhenFipsProviderActive() {
+        try {
+            Security.addProvider(new TestFipsProvider());
+            contextRunner
+                    .withPropertyValues("keeper.ksm.enforce-il5=true")
+                    .run(context -> assertThat(context).hasNotFailed());
+        } finally {
+            Security.removeProvider("BCFIPS");
+        }
+    }
+
+    static class TestFipsProvider extends Provider {
+        TestFipsProvider() {
+            super("BCFIPS", 1.0, "test fips provider");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate that a FIPS crypto provider is active when IL5 enforcement is enabled
- allow warning instead of failure with `crypto.check.mode=warn`
- test IL5 compliance validator behavior

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_689128f7c624832fb6cce03ec5ecddf3