### PR TITLE
Add audit logging IL5 compliance checks

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -27,6 +27,8 @@ On the first run, the starter reads the token from the file, redeems it to retri
 
 When `keeper.ksm.enforce-il5=true`, this one-time-token bootstrapping is blocked to maintain IL5 compliance. You may override this behavior by setting `bootstrap.check.mode=warn` to merely log a warning.
 
+IL5 enforcement also requires audit logging. Configure a logger named `com.keepersecurity` or `com.keepersecurity.ksm` at level `INFO` or higher and direct it to a secure sink such as a file appender. If no audit sink is detected the application fails to start by default. Override this behavior with `audit.check.mode=warn` to only log a warning.
+
 - **Option 2: Existing Config File** – If you already have a Keeper config JSON (e.g., from a previous initialization), you can just specify:
   ```properties
   keeper.ksm.secret-path = path/to/ksm-config.json

--- a/integration/spring-boot-starter-keeper-ksm/build.gradle
+++ b/integration/spring-boot-starter-keeper-ksm/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    compileOnly 'ch.qos.logback:logback-classic'
     compileOnlyApi 'org.bouncycastle:bc-fips:2.1.0'
     compileOnlyApi 'org.bouncycastle:bcprov-jdk18on:1.78' 
     compileOnlyApi 'software.amazon.awssdk:kms:2.20.28'

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/AuditLoggingValidatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/AuditLoggingValidatorTest.java
@@ -1,0 +1,65 @@
+package com.keepersecurity.spring.ksm.autoconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import java.util.Objects;
+
+class AuditLoggingValidatorTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(KeeperKsmAutoConfiguration.class)
+            .withPropertyValues(
+                    "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
+                    "keeper.ksm.container-type=sun_pkcs11",
+                    "keeper.ksm.hsm-provider=awsCloudHsm",
+                    "crypto.check.mode=warn");
+
+    @Test
+    void failsWithoutAuditSinkWhenIl5Enforced() {
+        contextRunner
+                .withPropertyValues("keeper.ksm.enforce-il5=true")
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    @Test
+    void warnsInsteadOfFailingWhenAuditModeWarn() {
+        contextRunner
+                .withPropertyValues(
+                        "keeper.ksm.enforce-il5=true",
+                        "audit.check.mode=warn")
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    void passesWhenAuditLoggerHasFileSink() {
+        configureLogging("logback-audit.xml");
+        contextRunner
+                .withPropertyValues("keeper.ksm.enforce-il5=true")
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    void failsWhenAuditLoggerBelowInfo() {
+        configureLogging("logback-audit-debug.xml");
+        contextRunner
+                .withPropertyValues("keeper.ksm.enforce-il5=true")
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    private void configureLogging(String resource) {
+        LoggerContext context = (LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory();
+        context.reset();
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(context);
+        try {
+            configurator.doConfigure(Objects.requireNonNull(
+                    Thread.currentThread().getContextClassLoader().getResource(resource)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
@@ -14,7 +14,8 @@ class Il5ComplianceValidatorTest {
             .withPropertyValues(
                     "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
                     "keeper.ksm.container-type=sun_pkcs11",
-                    "keeper.ksm.hsm-provider=awsCloudHsm");
+                    "keeper.ksm.hsm-provider=awsCloudHsm",
+                    "audit.check.mode=warn");
 
     @Test
     void failsWithoutFipsProviderWhenIl5Enforced() {

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
@@ -9,7 +9,9 @@ class Il5EnforcementTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withUserConfiguration(KeeperKsmAutoConfiguration.class)
-            .withPropertyValues("keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json");
+            .withPropertyValues(
+                    "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
+                    "audit.check.mode=warn");
 
     @Test
     void failsWithoutHsmProviderWhenIl5Enforced() {

--- a/integration/spring-boot-starter-keeper-ksm/src/test/resources/logback-audit-debug.xml
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/resources/logback-audit-debug.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>build/audit.log</file>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="com.keepersecurity" level="DEBUG" additivity="false">
+    <appender-ref ref="FILE"/>
+  </logger>
+</configuration>

--- a/integration/spring-boot-starter-keeper-ksm/src/test/resources/logback-audit.xml
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/resources/logback-audit.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>build/audit.log</file>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="com.keepersecurity" level="INFO" additivity="false">
+    <appender-ref ref="FILE"/>
+  </logger>
+</configuration>


### PR DESCRIPTION
## Summary
- require INFO-level audit logging to secure sink when IL5 is enforced
- allow overriding audit logging check with `audit.check.mode`
- add tests for audit logging compliance

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_6891fb5020b0832f9da0e33fa8c3a4a1