### PR TITLE
feat: add HSM savers

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -47,7 +47,7 @@ When `container-type` is `pkcs11`, this starter uses `Pkcs11ConfigStorage`. This
 
 ### Supported Container Types
 
-The `keeper.ksm.container-type` property accepts the following values.  Options marked *not implemented* are reserved for future releases.
+The `keeper.ksm.container-type` property accepts the following values.
 
 | Value | Default location | Security level | Compliance profile | Notes |
 |-------|-----------------|----------------|--------------------|-------|
@@ -56,17 +56,22 @@ The `keeper.ksm.container-type` property accepts the following values.  Options 
 | `bc_fips` | `ksm-config.bcfks` | IL-5 | FIPS 140-2 | requires Bouncy Castle FIPS |
 | `oracle_fips` | `ksm-config.p12` | IL-5 | FIPS 140-2 | Oracle FIPS provider |
 | `sun_pkcs11` | `pkcs11://slot/0/token/kms` | IL-5 | FIPS 140-2 | Sun PKCS#11 provider |
-| `aws`     | `aws-secrets://region/resource` | IL-5 | FedRAMP High | *not implemented* |
-| `azure`   | `azure-keyvault://vault/resource` | IL-5 | FedRAMP High | *not implemented* |
-| `aws_hsm` | `aws-cloudhsm://resource` | IL-5 | FedRAMP High | *not implemented* |
-| `azure_hsm` | `azure-dedicatedhsm://resource` | IL-5 | FedRAMP High | *not implemented* |
-| `google`  | `gcp-secretmanager://project/resource` | IL-4 | FedRAMP Moderate | *not implemented* |
+| `aws`     | `aws-secrets://region/resource` | IL-5 | FedRAMP High | requires AWS SDK |
+| `azure`   | `azure-keyvault://vault/resource` | IL-5 | FedRAMP High | requires Azure SDK |
+| `aws_hsm` | `aws-cloudhsm://resource` | IL-5 | FedRAMP High | PKCS#11 via CloudHSM |
+| `azure_hsm` | `azure-dedicatedhsm://resource` | IL-5 | FedRAMP High | PKCS#11 via Azure HSM |
+| `google`  | `gcp-secretmanager://project/resource` | IL-4 | FedRAMP Moderate | requires Google SDK |
 
 | `raw`     | `ksm-config.json` | IL-2 | None | plain JSON file |
-| `hsm`     | `pkcs11://slot/0/token/kms` | IL-5 | FIPS 140-2 | PKCS#11 HSM |
-| `fortanix` | `fortanix://token` | IL-5 | FIPS 140-2 | Fortanix DSM |
+| `hsm`     | `pkcs11://slot/0/token/kms` | IL-5 | FIPS 140-2 | generic PKCS#11 HSM |
+| `fortanix` | `fortanix://token` | IL-5 | FIPS 140-2 | Fortanix DSM via PKCS#11 |
 
 **Caution:** The `raw` container stores secrets in clear text and should only be used for testing or other non-production environments.
+
+AWS CloudHSM, Azure Dedicated HSM, Fortanix DSM and the generic `hsm` provider
+persist the configuration using a PKCS#11-backed keystore. Ensure the
+appropriate vendor PKCS#11 library and security provider are available on the
+classpath when using these options.
 
 ### IL-5 Provider Summary
 

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
@@ -178,6 +178,10 @@ public class KeeperKsmAutoConfiguration {
       case AWS -> AwsSaver.save(config, props);
       case AZURE -> AzureSaver.save(config, props);
       case GOOGLE -> GoogleSaver.save(config, props);
+      case AWS_HSM -> AwsHsmSaver.save(config, props);
+      case AZURE_HSM -> AzureHsmSaver.save(config, props);
+      case FORTANIX -> FortanixSaver.save(config, props);
+      case HSM -> HsmSaver.save(config, props);
       default -> throw new IllegalArgumentException("Unexpected or unimplemented provider: " + providerType);
     }
 
@@ -204,7 +208,7 @@ public class KeeperKsmAutoConfiguration {
     }
   }
 
-  private String resolveKeystoreType(KsmConfigProvider providerType) {
+  private static String resolveKeystoreType(KsmConfigProvider providerType) {
     return switch (providerType) {
       case BC_FIPS -> "BCFKS";
       case ORACLE_FIPS -> "PKCS12";
@@ -222,6 +226,7 @@ public class KeeperKsmAutoConfiguration {
           }
         };
       }
+      case HSM, AWS_HSM, AZURE_HSM, FORTANIX -> "PKCS11";
       default -> {
         String message = "Unsupported provider for keystore persistence: " + providerType;
         LOGGER.atWarn().log(message);
@@ -230,7 +235,7 @@ public class KeeperKsmAutoConfiguration {
     };
   }
 
-  private void saveConfigToKeystore(ObjectNode config, KeeperKsmProperties props) {
+  private static void saveConfigToKeystore(ObjectNode config, KeeperKsmProperties props) {
     try {
       Path keystorePath = props.getSecretPath();
       Files.createDirectories(keystorePath.getParent());
@@ -340,6 +345,30 @@ public class KeeperKsmAutoConfiguration {
       } catch (Exception e) {
         throw new IllegalStateException("Failed to persist the KMS Config to Google Secret Manager", e);
       }
+    }
+  }
+
+  private static class HsmSaver {
+    static void save(ObjectNode config, KeeperKsmProperties props) {
+      saveConfigToKeystore(config, props);
+    }
+  }
+
+  private static class AwsHsmSaver {
+    static void save(ObjectNode config, KeeperKsmProperties props) {
+      HsmSaver.save(config, props);
+    }
+  }
+
+  private static class AzureHsmSaver {
+    static void save(ObjectNode config, KeeperKsmProperties props) {
+      HsmSaver.save(config, props);
+    }
+  }
+
+  private static class FortanixSaver {
+    static void save(ObjectNode config, KeeperKsmProperties props) {
+      HsmSaver.save(config, props);
     }
   }
 


### PR DESCRIPTION
## Summary
- support HSM-based providers when consuming one-time token
- document HSM provider persistence options

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_689207399850832f9f812df273fbe5ce