### PR TITLE
test: check provider registration

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/ProviderSelectionTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/ProviderSelectionTest.java
@@ -2,7 +2,6 @@ package com.keepersecurity.spring.ksm.autoconfig;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.security.Security;
@@ -10,7 +9,10 @@ import java.security.Security;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = KeeperKsmAutoConfiguration.class,
-    properties = {"keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json"})
+    properties = {
+        "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
+        "keeper.ksm.provider=com.keepersecurity.spring.ksm.autoconfig.TestBcProvider"
+    })
 class ProviderSelectionTest {
 
     @AfterEach
@@ -19,7 +21,9 @@ class ProviderSelectionTest {
     }
 
     @Test
-    void contextLoadsWithDefaultProvider() {
-        assertNotNull(Security.getProviders(), "Security providers should be available");
+    void bcProviderSelected() {
+        Security.addProvider(new TestBcProvider());
+        assertNotNull(Security.getProvider("BC"), "BC provider should be registered");
     }
+
 }

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/TestBcProvider.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/TestBcProvider.java
@@ -1,0 +1,9 @@
+package com.keepersecurity.spring.ksm.autoconfig;
+
+import java.security.Provider;
+
+public class TestBcProvider extends Provider {
+    public TestBcProvider() {
+        super("BC", 1.0, "test bc provider");
+    }
+}


### PR DESCRIPTION
## Summary
- verify BC provider registration via Security.getProvider
- add minimal BC provider for testing

## Testing
- `cd integration/spring-boot-starter-keeper-ksm && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_68921607938c832fadb51faf0107ee3b