### PR TITLE
Use logger and custom exception in Spring Boot example secret fetch

### DIFF
--- a/examples/spring-boot/src/main/java/com/example/SecretFetchException.java
+++ b/examples/spring-boot/src/main/java/com/example/SecretFetchException.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class SecretFetchException extends RuntimeException {
+
+    public SecretFetchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/examples/spring-boot/src/main/java/com/example/SecretService.java
+++ b/examples/spring-boot/src/main/java/com/example/SecretService.java
@@ -2,6 +2,8 @@ package com.example;
 
 import com.keepersecurity.secretsManager.core.SecretsManager;
 import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -15,6 +17,8 @@ import java.util.Map;
 
 @Service
 public class SecretService {
+
+    private static final Logger logger = LoggerFactory.getLogger(SecretService.class);
 
     private final SecretsManagerOptions options;
     private final Environment environment;
@@ -32,7 +36,8 @@ public class SecretService {
             List<String> results = SecretsManager.getNotationResults(options, keeperNotation);
             return results.isEmpty() ? null : results.get(0);
         } catch (Exception e) {
-            return null;
+            logger.error("Failed to fetch secret for notation {}", keeperNotation, e);
+            throw new SecretFetchException("Failed to fetch secret", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- log secret retrieval failures
- rethrow `SecretFetchException` instead of returning `null`

## Testing
- `./gradlew test` *(fails: Username must not be null)*

------
https://chatgpt.com/codex/tasks/task_b_68921a7fd160832fae3a27bb3a1ac898