### PR TITLE
Add tests for Spring Boot example service and controller

### DIFF
--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'com.keepersecurity:spring-boot-starter-keeper-ksm:0.0.1-SNAPSHOT'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-inline'
 }
 
 tasks.named('test') {

--- a/examples/spring-boot/src/test/java/com/example/SecretControllerTest.java
+++ b/examples/spring-boot/src/test/java/com/example/SecretControllerTest.java
@@ -1,0 +1,55 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SecretController.class)
+class SecretControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    SecretService secretService;
+
+    @Test
+    void indexPopulatesModel() throws Exception {
+        Map<String, Object> config = Map.of("key", "value");
+        when(secretService.getSpringConfig()).thenReturn(config);
+
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"))
+                .andExpect(model().attribute("secret", (Object) null))
+                .andExpect(model().attribute("configMap", config));
+
+        verify(secretService).getSpringConfig();
+        verifyNoMoreInteractions(secretService);
+    }
+
+    @Test
+    void fetchPopulatesModel() throws Exception {
+        Map<String, Object> config = Map.of("k", "v");
+        when(secretService.fetchSecret("notation")).thenReturn("secret");
+        when(secretService.getSpringConfig()).thenReturn(config);
+
+        mockMvc.perform(post("/").param("notation", "notation"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"))
+                .andExpect(model().attribute("secret", "secret"))
+                .andExpect(model().attribute("configMap", config));
+
+        verify(secretService).fetchSecret("notation");
+        verify(secretService).getSpringConfig();
+        verifyNoMoreInteractions(secretService);
+    }
+}

--- a/examples/spring-boot/src/test/java/com/example/SecretServiceTest.java
+++ b/examples/spring-boot/src/test/java/com/example/SecretServiceTest.java
@@ -1,0 +1,58 @@
+package com.example;
+
+import com.keepersecurity.secretsManager.core.SecretsManager;
+import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SecretServiceTest {
+
+    @Mock
+    SecretsManagerOptions options;
+    @Mock
+    Environment environment;
+
+    @Test
+    void fetchSecretReturnsValue() {
+        try (MockedStatic<SecretsManager> secretsManager = mockStatic(SecretsManager.class)) {
+            secretsManager.when(() -> SecretsManager.getNotationResults(options, "keeper://record/field"))
+                    .thenReturn(List.of("value"));
+
+            SecretService service = new SecretService(options, environment);
+            String result = service.fetchSecret("keeper://record/field");
+
+            assertThat(result).isEqualTo("value");
+        }
+    }
+
+    @Test
+    void fetchSecretReturnsNullForBlank() {
+        SecretService service = new SecretService(options, environment);
+        String result = service.fetchSecret("  ");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void fetchSecretThrowsOnError() {
+        try (MockedStatic<SecretsManager> secretsManager = mockStatic(SecretsManager.class)) {
+            secretsManager.when(() -> SecretsManager.getNotationResults(options, "keeper://bad"))
+                    .thenThrow(new RuntimeException("boom"));
+
+            SecretService service = new SecretService(options, environment);
+
+            assertThatThrownBy(() -> service.fetchSecret("keeper://bad"))
+                    .isInstanceOf(SecretFetchException.class)
+                    .hasMessage("Failed to fetch secret");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Mockito inline dependency for static method mocking
- add SecretService tests covering success, blank notation, and exception cases
- add WebMvc tests ensuring SecretController populates the model on GET and POST

## Testing
- `GH_REPO_USER= GH_REPO_TOKEN= ./gradlew test` *(fails: Could not resolve com.keepersecurity:spring-boot-starter-keeper-ksm:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_b_68921e5f14f8832fbd29f59e7c828a7f