### PR TITLE
docs: add javadoc to spring boot example

### DIFF
--- a/examples/spring-boot/src/main/java/com/example/Application.java
+++ b/examples/spring-boot/src/main/java/com/example/Application.java
@@ -3,9 +3,17 @@ package com.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Example Spring Boot application bootstrap class.
+ */
 @SpringBootApplication
 public class Application {
 
+    /**
+     * Launches the Spring Boot application.
+     *
+     * @param args command line arguments
+     */
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }

--- a/examples/spring-boot/src/main/java/com/example/SecretController.java
+++ b/examples/spring-boot/src/main/java/com/example/SecretController.java
@@ -5,15 +5,29 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
+/**
+ * Controller that renders the example page and processes secret lookups.
+ */
 @Controller
 public class SecretController {
 
     private final SecretService secretService;
 
+    /**
+     * Creates a new controller with access to the secret service.
+     *
+     * @param secretService service used to fetch secrets and configuration
+     */
     public SecretController(SecretService secretService) {
         this.secretService = secretService;
     }
 
+    /**
+     * Displays the initial page with configuration values.
+     *
+     * @param model model used to render the view
+     * @return view name
+     */
     @GetMapping("/")
     String index(Model model) {
         model.addAttribute("secret", null);
@@ -21,6 +35,13 @@ public class SecretController {
         return "index";
     }
 
+    /**
+     * Handles form submission to fetch a secret for the provided notation.
+     *
+     * @param notation Keeper notation supplied by the user
+     * @param model    model used to render the view
+     * @return view name
+     */
     @PostMapping("/")
     String fetch(String notation, Model model) {
         String secret = secretService.fetchSecret(notation);

--- a/examples/spring-boot/src/main/java/com/example/SecretService.java
+++ b/examples/spring-boot/src/main/java/com/example/SecretService.java
@@ -15,6 +15,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Service that fetches secrets from Keeper Secrets Manager and exposes
+ * the resolved Spring configuration.
+ */
 @Service
 public class SecretService {
 
@@ -23,11 +27,24 @@ public class SecretService {
     private final SecretsManagerOptions options;
     private final Environment environment;
 
+    /**
+     * Creates a new service for retrieving secrets.
+     *
+     * @param options      configuration for the Secrets Manager client
+     * @param environment  Spring environment to read configuration from
+     */
     public SecretService(SecretsManagerOptions options, Environment environment) {
         this.options = options;
         this.environment = environment;
     }
 
+    /**
+     * Returns the first secret value that matches the given Keeper notation.
+     *
+     * @param keeperNotation notation path identifying the secret
+     * @return the secret value or {@code null} if not found
+     * @throws SecretFetchException if retrieval fails
+     */
     public String fetchSecret(String keeperNotation) {
         if (keeperNotation == null || keeperNotation.isBlank()) {
             return null;
@@ -41,6 +58,11 @@ public class SecretService {
         }
     }
 
+    /**
+     * Returns a map of all resolved Spring configuration properties.
+     *
+     * @return property name to value mappings
+     */
     public Map<String, Object> getSpringConfig() {
         Map<String, Object> props = new LinkedHashMap<>();
         if (environment instanceof ConfigurableEnvironment configurableEnvironment) {


### PR DESCRIPTION
## Summary
- document Spring Boot example Application entry point
- add service and controller Javadoc for secret lookup demo

## Testing
- `./gradlew test` *(fails: Could not resolve com.keepersecurity:spring-boot-starter-keeper-ksm:0.0.1-SNAPSHOT. Username must not be null)*

------
https://chatgpt.com/codex/tasks/task_b_689222c158b8832fbdb4e93949b0f28e