### PR TITLE
feat: allow stale cache when KSM is offline

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/README.md
+++ b/integration/spring-boot-starter-keeper-ksm/README.md
@@ -161,6 +161,19 @@ keeper:
       persist: false
 ```
 
+To tolerate temporary KSM outages and still read secrets from the cache, enable
+the fallback to expired entries:
+
+```yaml
+keeper:
+  ksm:
+    cache:
+      allow-stale-if-offline: true   # Allows expired secrets if KSM is down
+```
+
+Use with caution. Enabling this may help during outages, but stale secrets may
+violate IL5 security posture.
+
 You may also override the caching strategy by defining a custom `ConfigStorage` bean:
 
 ```java

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
@@ -63,6 +63,13 @@ public class KeeperKsmProperties {
     private boolean persist = true;
 
     /**
+     * If true, expired secrets may still be returned from cache
+     * when the KSM service is unreachable.
+     * Default is false — expired secrets will cause a failure.
+     */
+    private boolean allowStaleIfOffline = false;
+
+    /**
      * Indicates whether caching is enabled.
      *
      * @return {@code true} if caching is enabled
@@ -96,6 +103,26 @@ public class KeeperKsmProperties {
      */
     public void setPersist(boolean persist) {
       this.persist = persist;
+    }
+
+    /**
+     * Indicates whether expired secrets may be served when the KSM
+     * service cannot be reached.
+     *
+     * @return {@code true} to allow stale secrets if offline
+     */
+    public boolean isAllowStaleIfOffline() {
+      return allowStaleIfOffline;
+    }
+
+    /**
+     * Enables or disables returning stale secrets when the KSM service is
+     * unavailable.
+     *
+     * @param allowStaleIfOffline {@code true} to allow stale secrets if offline
+     */
+    public void setAllowStaleIfOffline(boolean allowStaleIfOffline) {
+      this.allowStaleIfOffline = allowStaleIfOffline;
     }
   }
 

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
@@ -172,6 +172,13 @@ public class KeeperKsmAutoConfiguration {
       LOGGER.atDebug().setCause(e).log("SecretsManagerOptions does not support cache TTL configuration");
     }
     try {
+      options.getClass().getMethod("setAllowStaleCacheOnFailure", boolean.class)
+          .invoke(options, properties.getCache().isAllowStaleIfOffline());
+    } catch (ReflectiveOperationException e) {
+      LOGGER.atDebug().setCause(e)
+          .log("SecretsManagerOptions does not support stale cache failover configuration");
+    }
+    try {
       Class<?> storageClass;
       try {
         storageClass = Class.forName("com.keepersecurity.secretsManager.core.ConfigStorage");

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
@@ -371,6 +371,13 @@ public class KeeperKsmProperties implements InitializingBean{
     private Duration ttl = Duration.ofSeconds(300);
 
     /**
+     * If true, expired secrets may still be returned from cache when the KSM
+     * service is unreachable. Default is {@code false} for stricter
+     * environments such as IL5.
+     */
+    private boolean allowStaleIfOffline = false;
+
+    /**
      * Returns whether caching is enabled.
      *
      * @return {@code true} to enable caching
@@ -441,6 +448,26 @@ public class KeeperKsmProperties implements InitializingBean{
      */
     public void setTtl(Duration ttl) {
       this.ttl = ttl;
+    }
+
+    /**
+     * Indicates whether expired secrets may be served when the KSM service
+     * cannot be reached.
+     *
+     * @return {@code true} to allow stale secrets if offline
+     */
+    public boolean isAllowStaleIfOffline() {
+      return allowStaleIfOffline;
+    }
+
+    /**
+     * Enables or disables returning stale secrets when the KSM service is
+     * unavailable.
+     *
+     * @param allowStaleIfOffline {@code true} to allow stale secrets if offline
+     */
+    public void setAllowStaleIfOffline(boolean allowStaleIfOffline) {
+      this.allowStaleIfOffline = allowStaleIfOffline;
     }
   }
 


### PR DESCRIPTION
## Summary
- add `keeper.ksm.cache.allow-stale-if-offline` property
- pass value to `SecretsManagerOptions` via `setAllowStaleCacheOnFailure`
- document fallback option in README

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_689259128a28832fb450b4d01ce5e089