### PR TITLE
Refactor Spring Boot example to use local starter

### DIFF
--- a/examples/spring-boot/README.md
+++ b/examples/spring-boot/README.md
@@ -3,6 +3,10 @@
 This sample demonstrates how to use the `spring-boot-starter-keeper-ksm` starter
 in a minimal Spring Boot application.
 
+The example is linked to the starter within this repository using a Gradle
+composite build, so you can run it without configuring access to Keeper's GitHub
+Packages registry.
+
 ## Keeper Spring Boot Example
 
 This example demonstrates fetching KSM secrets using a Thymeleaf frontend.

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -15,22 +15,16 @@ java {
 
 repositories {
     mavenCentral()
-    maven {
-        name = "keeper-central"
-        credentials {
-            username = System.getenv("GH_REPO_USER")
-            password = System.getenv("GH_REPO_TOKEN")
-        }
-        url = uri("https://maven.pkg.github.com/Keeper-Security/keeper-central")
-    }
+    mavenLocal()
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'com.keepersecurity:spring-boot-starter-keeper-ksm:0.0.1-SNAPSHOT'
+    implementation 'com.keepersecurity.secrets-manager:core:17.0.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mockito:mockito-inline'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
 }
 
 tasks.named('test') {

--- a/examples/spring-boot/settings.gradle
+++ b/examples/spring-boot/settings.gradle
@@ -6,3 +6,4 @@
  */
 
 rootProject.name = 'spring-boot'
+includeBuild('../../integration/spring-boot-starter-keeper-ksm')

--- a/examples/spring-boot/src/main/resources/templates/index.html
+++ b/examples/spring-boot/src/main/resources/templates/index.html
@@ -16,7 +16,7 @@
 <div>
     <h2>Configuration</h2>
     <ul>
-        <li th:each="entry : ${#maps.entries(configMap)}">
+        <li th:each="entry : ${configMap}">
             <span th:text="${entry.key}"></span>: <span th:text="${entry.value}"></span>
         </li>
     </ul>


### PR DESCRIPTION
## Summary
- Resolve Spring Boot example's starter locally via composite build
- Simplify Thymeleaf map iteration
- Document local starter usage

## Testing
- `./gradlew test` in integration/spring-boot-starter-keeper-ksm
- `./gradlew test` in examples/spring-boot


------
https://chatgpt.com/codex/tasks/task_b_68926030ccec832f9aa40ac21f74f408