### PR TITLE
Add constructors with Javadoc for KeeperKsm properties classes

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
@@ -13,6 +13,12 @@ public class KeeperKsmProperties {
   private final Config config = new Config();
 
   /**
+   * Creates a new {@code KeeperKsmProperties} instance with default settings.
+   */
+  public KeeperKsmProperties() {
+  }
+
+  /**
    * Indicates whether IL‑5 compliance is enforced during initialization.
    *
    * @return {@code true} if IL‑5 enforcement is enabled
@@ -68,6 +74,12 @@ public class KeeperKsmProperties {
      * Default is false — expired secrets will cause a failure.
      */
     private boolean allowStaleIfOffline = false;
+
+    /**
+     * Private constructor to prevent external instantiation.
+     */
+    private Cache() {
+    }
 
     /**
      * Indicates whether caching is enabled.
@@ -144,6 +156,12 @@ public class KeeperKsmProperties {
      * Whether to allow fallback loading from a one-time-token.
      */
     private boolean allowFallback = true;
+
+    /**
+     * Private constructor to prevent external instantiation.
+     */
+    private Config() {
+    }
 
     /**
      * Returns the configured HSM provider identifier.

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmProperties.java
@@ -23,7 +23,11 @@ public class KeeperKsmProperties implements InitializingBean{
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KeeperKsmProperties.class);
 
-  // package-private constructor required for configuration binding
+  /**
+   * Creates a new {@code KeeperKsmProperties} instance.
+   * The constructor is package-private so that Spring can perform
+   * configuration binding while keeping the type out of the public API.
+   */
   KeeperKsmProperties() {
   }
 
@@ -376,6 +380,12 @@ public class KeeperKsmProperties implements InitializingBean{
      * environments such as IL5.
      */
     private boolean allowStaleIfOffline = false;
+
+    /**
+     * Private constructor to prevent external instantiation.
+     */
+    private CacheProperties() {
+    }
 
     /**
      * Returns whether caching is enabled.


### PR DESCRIPTION
## Summary
- document default constructor for `KeeperKsmProperties`
- prevent external instantiation of nested `Cache`, `Config`, and `CacheProperties` classes with private constructors

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68927064a1fc832fb49c481202dc1408