### PR TITLE
refactor: use Lombok for configuration properties

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
@@ -1,15 +1,30 @@
 package com.keepersecurity.ksm.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Configuration properties for Keeper Secrets Manager integration.
  */
 @ConfigurationProperties(prefix = "keeper.ksm")
+@Getter
+@Setter
 public class KeeperKsmProperties {
 
+  /**
+   * Indicates whether IL‑5 compliance is enforced during initialization.
+   */
   private boolean enforceIl5 = false;
+
+  /**
+   * Cache-related configuration settings.
+   */
   private final Cache cache = new Cache();
+
+  /**
+   * Keeper configuration source settings.
+   */
   private final Config config = new Config();
 
   /**
@@ -19,44 +34,10 @@ public class KeeperKsmProperties {
   }
 
   /**
-   * Indicates whether IL‑5 compliance is enforced during initialization.
-   *
-   * @return {@code true} if IL‑5 enforcement is enabled
-   */
-  public boolean isEnforceIl5() {
-    return enforceIl5;
-  }
-
-  /**
-   * Enables or disables IL‑5 enforcement.
-   *
-   * @param enforceIl5 {@code true} to enforce IL‑5 compliance
-   */
-  public void setEnforceIl5(boolean enforceIl5) {
-    this.enforceIl5 = enforceIl5;
-  }
-
-  /**
-   * Returns cache-related configuration settings.
-   *
-   * @return cache configuration
-   */
-  public Cache getCache() {
-    return cache;
-  }
-
-  /**
-   * Returns Keeper configuration source settings.
-   *
-   * @return configuration source settings
-   */
-  public Config getConfig() {
-    return config;
-  }
-
-  /**
    * Cache-related configuration options.
    */
+  @Getter
+  @Setter
   public static class Cache {
     /**
      * Enables in-memory caching of Keeper secrets.
@@ -81,66 +62,13 @@ public class KeeperKsmProperties {
     private Cache() {
     }
 
-    /**
-     * Indicates whether caching is enabled.
-     *
-     * @return {@code true} if caching is enabled
-     */
-    public boolean isEnabled() {
-      return enabled;
-    }
-
-    /**
-     * Enables or disables caching of secrets.
-     *
-     * @param enabled {@code true} to enable caching
-     */
-    public void setEnabled(boolean enabled) {
-      this.enabled = enabled;
-    }
-
-    /**
-     * Indicates whether cached secrets are persisted across restarts.
-     *
-     * @return {@code true} if persistent caching is enabled
-     */
-    public boolean isPersist() {
-      return persist;
-    }
-
-    /**
-     * Enables or disables persistent cache storage.
-     *
-     * @param persist {@code true} to persist cached secrets
-     */
-    public void setPersist(boolean persist) {
-      this.persist = persist;
-    }
-
-    /**
-     * Indicates whether expired secrets may be served when the KSM
-     * service cannot be reached.
-     *
-     * @return {@code true} to allow stale secrets if offline
-     */
-    public boolean isAllowStaleIfOffline() {
-      return allowStaleIfOffline;
-    }
-
-    /**
-     * Enables or disables returning stale secrets when the KSM service is
-     * unavailable.
-     *
-     * @param allowStaleIfOffline {@code true} to allow stale secrets if offline
-     */
-    public void setAllowStaleIfOffline(boolean allowStaleIfOffline) {
-      this.allowStaleIfOffline = allowStaleIfOffline;
-    }
   }
 
   /**
    * Configuration source and HSM provider settings.
    */
+  @Getter
+  @Setter
   public static class Config {
     /**
      * HSM provider type (e.g., "pkcs11", "softhsm2", "bouncycastle-fips").
@@ -163,59 +91,6 @@ public class KeeperKsmProperties {
     private Config() {
     }
 
-    /**
-     * Returns the configured HSM provider identifier.
-     *
-     * @return HSM provider name or {@code null}
-     */
-    public String getHsmProvider() {
-      return hsmProvider;
-    }
-
-    /**
-     * Sets the HSM provider identifier to use.
-     *
-     * @param hsmProvider provider name
-     */
-    public void setHsmProvider(String hsmProvider) {
-      this.hsmProvider = hsmProvider;
-    }
-
-    /**
-     * Returns the source location for Keeper configuration.
-     *
-     * @return configuration source
-     */
-    public String getSource() {
-      return source;
-    }
-
-    /**
-     * Sets the source location for Keeper configuration.
-     *
-     * @param source file path, URI or PKCS#11 locator
-     */
-    public void setSource(String source) {
-      this.source = source;
-    }
-
-    /**
-     * Indicates whether a one-time token fallback is permitted.
-     *
-     * @return {@code true} if fallback is allowed
-     */
-    public boolean isAllowFallback() {
-      return allowFallback;
-    }
-
-    /**
-     * Enables or disables fallback loading from a one-time token.
-     *
-     * @param allowFallback {@code true} to allow fallback
-     */
-    public void setAllowFallback(boolean allowFallback) {
-      this.allowFallback = allowFallback;
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- use Lombok @Getter/@Setter to manage KeeperKsmProperties and nested classes
- remove manual getters and setters while retaining documentation

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68936486552c832f96e76c5a6d3f0f4a