### PR TITLE
Use Lombok StandardException for one-time token exception

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/OneTimeTokenConsumedException.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/OneTimeTokenConsumedException.java
@@ -1,20 +1,14 @@
 package com.keepersecurity.spring.ksm.autoconfig;
 
+import lombok.experimental.StandardException;
+
 /**
  * Exception thrown after a one-time token has been consumed.
  * <p>
  * This signals that the application should terminate and remove the
  * {@code keeper.ksm.one-time-token} property before restarting.
  */
+@StandardException
 public class OneTimeTokenConsumedException extends RuntimeException {
-
-    /**
-     * Creates a new exception indicating a one-time token has already been used.
-     *
-     * @param message detail message describing the condition
-     */
-    public OneTimeTokenConsumedException(String message) {
-        super(message);
-    }
 }
 


### PR DESCRIPTION
## Summary
- leverage Lombok's `@StandardException` for OneTimeTokenConsumedException

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_689364c89448832f827e0ae26e215427