### PR TITLE
refactor: use Lombok logging in KSM starter

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/ksm/config/KeeperKsmProperties.java
@@ -1,11 +1,13 @@
 package com.keepersecurity.ksm.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Configuration properties for Keeper Secrets Manager integration.
  */
 @ConfigurationProperties(prefix = "keeper.ksm")
+@Slf4j
 public class KeeperKsmProperties {
 
   private boolean enforceIl5 = false;

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidator.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidator.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.env.Environment;
+import lombok.extern.slf4j.Slf4j;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -15,9 +16,8 @@ import ch.qos.logback.core.FileAppender;
 /**
  * Validates that a FIPS-certified crypto provider is active when IL5 enforcement is enabled.
  */
+@Slf4j
 class Il5ComplianceValidator implements InitializingBean {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(Il5ComplianceValidator.class);
 
   private final KeeperKsmProperties properties;
   private final Environment environment;
@@ -55,9 +55,9 @@ class Il5ComplianceValidator implements InitializingBean {
     if (!fipsPresent) {
       String message = "No FIPS-certified crypto provider (e.g. BCFIPS) is active. IL5 mode requires FIPS-compliant crypto.";
       if ("warn".equalsIgnoreCase(environment.getProperty("crypto.check.mode"))) {
-        LOGGER.atWarn().log(message);
+        log.atWarn().log(message);
       } else {
-        LOGGER.atError().log(message);
+        log.atError().log(message);
         throw new IllegalStateException(message);
       }
     }
@@ -72,9 +72,9 @@ class Il5ComplianceValidator implements InitializingBean {
       String message =
           "Audit logger level for 'com.keepersecurity' or 'com.keepersecurity.ksm' must be set to INFO or higher.";
       if (warn) {
-        LOGGER.atWarn().log(message);
+        log.atWarn().log(message);
       } else {
-        LOGGER.atError().log(message);
+        log.atError().log(message);
         throw new IllegalStateException(message);
       }
     }
@@ -86,9 +86,9 @@ class Il5ComplianceValidator implements InitializingBean {
       String message =
           "Audit logging not detected. IL5 enforcement requires audit visibility.";
       if (warn) {
-        LOGGER.atWarn().log(message);
+        log.atWarn().log(message);
       } else {
-        LOGGER.atError().log(message);
+        log.atError().log(message);
         throw new IllegalStateException(message);
       }
     }

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocator.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/config/KsmPropertySourceLocator.java
@@ -14,22 +14,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Loads Keeper Secrets Manager records and exposes them as Spring configuration
  * properties.
  */
 @ConditionalOnClass(SecretsManager.class)
+@Slf4j
 public class KsmPropertySourceLocator implements PropertySourceLocator {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(KsmPropertySourceLocator.class);
 
   private final SecretsManagerOptions options;
   private final KeeperKsmProperties properties;
@@ -114,7 +112,7 @@ public class KsmPropertySourceLocator implements PropertySourceLocator {
       }
       return val != null ? val.toString() : null;
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      LOGGER.warn("Failed to extract value from field {}", field, e);
+      log.warn("Failed to extract value from field {}", field, e);
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- use Lombok `@Slf4j` in IL5 compliance validator
- migrate auto configuration and property source locator to Lombok logging
- annotate configuration properties with `@Slf4j`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_689364f1fb44832f9fce02c5ce91c840