### PR TITLE
Expand AGENTS instructions across repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,26 @@
 # Agent Instructions
 
-This repository hosts the Keeper Secrets Manager Spring Boot starter alongside other integrations.
+This repository hosts KSM SDKs, integrations, and examples.
 
-- Most development is done in `integration/spring-boot-starter-keeper-ksm`. That directory has its own `AGENTS.md` with detailed build instructions.
-- Always consult and follow that file when working on the starter. It requires JDK 21 and running `./gradlew test` before committing.
-- For other parts of the repo, keep documentation and configuration consistent with the existing style.
+The repository is organized into:
+
+- `sdk/` contains SDK projects for dotnet, golang, java, javascript,
+  python and rust.
+- `integration/` contains integration projects for
+  `keeper_secrets_manager_ansible`,
+  `keeper_secrets_manager_azure_pipeline_extension`,
+  `keeper_secrets_manager_cli`, `servicenow-external-credential-resolver`,
+  `spring-boot-starter-keeper-ksm` and `vault-plugin-secrets-ksm`.
+- `examples/` contains sample projects:
+  - `dotNet` for the dotnet SDK
+  - `go` for the golang SDK
+  - `java` for the java SDK
+  - `javascript` for the javascript SDK
+  - `kotlin` for the java SDK
+  - `python` for the python SDK
+  - `spring-boot` for the `spring-boot-starter-keeper-ksm` integration
+
+This branch focuses on development of the `integration/spring-boot-starter-keeper-ksm`
+integration and the `examples/spring-boot` example. Keep the example consistent
+with the starter.
+

--- a/examples/dotNet/AGENTS.md
+++ b/examples/dotNet/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory provides a dotnet SDK example. Follow root instructions when modifying files here.

--- a/examples/go/AGENTS.md
+++ b/examples/go/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory provides a golang SDK example. Follow root instructions when modifying files here.

--- a/examples/java/AGENTS.md
+++ b/examples/java/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory provides a java SDK example. Follow root instructions when modifying files here.

--- a/examples/javascript/AGENTS.md
+++ b/examples/javascript/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory provides a javascript SDK example. Follow root instructions when modifying files here.

--- a/examples/kotlin/AGENTS.md
+++ b/examples/kotlin/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory provides a kotlin SDK example. Follow root instructions when modifying files here.

--- a/examples/python/AGENTS.md
+++ b/examples/python/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory provides a python SDK example. Follow root instructions when modifying files here.

--- a/examples/spring-boot/AGENTS.md
+++ b/examples/spring-boot/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory provides a Spring Boot example for the spring-boot-starter-keeper-ksm integration. Keep it consistent with `integration/spring-boot-starter-keeper-ksm`.

--- a/integration/keeper_secrets_manager_ansible/AGENTS.md
+++ b/integration/keeper_secrets_manager_ansible/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the keeper_secrets_manager_ansible integration for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/integration/keeper_secrets_manager_azure_pipeline_extension/AGENTS.md
+++ b/integration/keeper_secrets_manager_azure_pipeline_extension/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the keeper_secrets_manager_azure_pipeline_extension integration for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/integration/keeper_secrets_manager_cli/AGENTS.md
+++ b/integration/keeper_secrets_manager_cli/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the keeper_secrets_manager_cli integration for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/integration/servicenow-external-credential-resolver/AGENTS.md
+++ b/integration/servicenow-external-credential-resolver/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the servicenow-external-credential-resolver integration for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/integration/spring-boot-starter-keeper-ksm/AGENTS.md
+++ b/integration/spring-boot-starter-keeper-ksm/AGENTS.md
@@ -38,3 +38,5 @@ switch (agentType) {
 
 - If a new class only has an implicit constructor (i.e., none defined), **add an explicit constructor with Javadoc**.
 - **Always document new classes and methods** with meaningful Javadoc, unless explicitly told not to.
+
+- Ensure the `examples/spring-boot` project stays in sync with this starter.

--- a/integration/vault-plugin-secrets-ksm/AGENTS.md
+++ b/integration/vault-plugin-secrets-ksm/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the vault-plugin-secrets-ksm integration for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/sdk/dotNet/AGENTS.md
+++ b/sdk/dotNet/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the dotnet SDK for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/sdk/golang/AGENTS.md
+++ b/sdk/golang/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the golang SDK for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/sdk/java/AGENTS.md
+++ b/sdk/java/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the java SDK for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/sdk/javascript/AGENTS.md
+++ b/sdk/javascript/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the javascript SDK for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/sdk/python/AGENTS.md
+++ b/sdk/python/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the python SDK for Keeper Secrets Manager. Follow root instructions when modifying files here.

--- a/sdk/rust/AGENTS.md
+++ b/sdk/rust/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This directory contains the rust SDK for Keeper Secrets Manager. Follow root instructions when modifying files here.


### PR DESCRIPTION
## Summary
- clarify repository scope and spring-boot focus in root AGENTS
- add AGENTS files for every SDK, integration, and example project
- note in spring-boot files to keep example and starter consistent

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory, open '/workspace/secrets-manager/package.json')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'keeper_secrets_manager_cli'; 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68936dd1e068832f99851b4eda71949a