### PR TITLE
Document PKCS11Config and OneTimeTokenConsumedException

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/OneTimeTokenConsumedException.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/OneTimeTokenConsumedException.java
@@ -1,15 +1,42 @@
 package com.keepersecurity.spring.ksm.autoconfig;
 
-import lombok.experimental.StandardException;
-
 /**
  * Exception thrown after a one-time token has been consumed.
- * <p>
- * This signals that the application should terminate and remove the
- * {@code keeper.ksm.one-time-token} property before restarting.
+ *
+ * <p>This signals that the application should terminate and remove the {@code
+ * keeper.ksm.one-time-token} property before restarting.
  */
-@StandardException
 public class OneTimeTokenConsumedException extends RuntimeException {
   private static final long serialVersionUID = 1L;
-}
 
+  /** Creates a new exception with no detail message or cause. */
+  public OneTimeTokenConsumedException() {}
+
+  /**
+   * Creates a new exception with the specified detail message.
+   *
+   * @param message detail message
+   */
+  public OneTimeTokenConsumedException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a new exception with the specified cause.
+   *
+   * @param cause underlying cause
+   */
+  public OneTimeTokenConsumedException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * Creates a new exception with the specified detail message and cause.
+   *
+   * @param message detail message
+   * @param cause underlying cause
+   */
+  public OneTimeTokenConsumedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/PKCS11Config.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/PKCS11Config.java
@@ -1,8 +1,8 @@
 package com.keepersecurity.spring.ksm.autoconfig;
 
 /**
- * Simple representation of a PKCS#11 configuration describing the path to the native library.
+ * Simple representation of a PKCS#11 configuration.
+ *
+ * @param libraryPath path to the native PKCS#11 library
  */
-public record PKCS11Config(String libraryPath) {
-}
-
+public record PKCS11Config(String libraryPath) {}


### PR DESCRIPTION
## Summary
- document PKCS#11 library path parameter
- add explicit constructors with Javadoc for one-time token exception

## Testing
- `./gradlew test`
- `./gradlew javadoc`


------
https://chatgpt.com/codex/tasks/task_b_6893883e5180832f9926bd1dd19570f9