### PR TITLE
refactor: rely on provided KSM beans

### DIFF
--- a/examples/spring-boot/src/main/java/com/example/Application.java
+++ b/examples/spring-boot/src/main/java/com/example/Application.java
@@ -1,11 +1,16 @@
 package com.example;
 
+import com.keepersecurity.secretsManager.core.InMemoryStorage;
+import com.keepersecurity.secretsManager.core.KeyValueStorage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
-/**
- * Example Spring Boot application bootstrap class.
- */
+/** Example Spring Boot application bootstrap class. */
 @SpringBootApplication
 public class Application {
 
@@ -16,5 +21,12 @@ public class Application {
    */
   public static void main(String[] args) {
     SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  KeyValueStorage ksmConfig(@Value("${keeper.ksm.secret-path}") String secretPath)
+      throws IOException {
+    String json = Files.readString(Path.of(secretPath));
+    return new InMemoryStorage(json);
   }
 }

--- a/examples/spring-boot/src/test/java/com/example/SecretControllerTest.java
+++ b/examples/spring-boot/src/test/java/com/example/SecretControllerTest.java
@@ -1,55 +1,58 @@
 package com.example;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.keepersecurity.secretsManager.core.KeyValueStorage;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Map;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @WebMvcTest(SecretController.class)
 class SecretControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @MockBean(name = "ksmConfig")
+  KeyValueStorage ksmConfig;
 
-    @MockBean
-    SecretService secretService;
+  @Autowired MockMvc mockMvc;
 
-    @Test
-    void indexPopulatesModel() throws Exception {
-        Map<String, Object> config = Map.of("key", "value");
-        when(secretService.getSpringConfig()).thenReturn(config);
+  @MockBean SecretService secretService;
 
-        mockMvc.perform(get("/"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("index"))
-                .andExpect(model().attribute("secret", (Object) null))
-                .andExpect(model().attribute("configMap", config));
+  @Test
+  void indexPopulatesModel() throws Exception {
+    Map<String, Object> config = Map.of("key", "value");
+    when(secretService.getSpringConfig()).thenReturn(config);
 
-        verify(secretService).getSpringConfig();
-        verifyNoMoreInteractions(secretService);
-    }
+    mockMvc
+        .perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("index"))
+        .andExpect(model().attribute("secret", (Object) null))
+        .andExpect(model().attribute("configMap", config));
 
-    @Test
-    void fetchPopulatesModel() throws Exception {
-        Map<String, Object> config = Map.of("k", "v");
-        when(secretService.fetchSecret("notation")).thenReturn("secret");
-        when(secretService.getSpringConfig()).thenReturn(config);
+    verify(secretService).getSpringConfig();
+    verifyNoMoreInteractions(secretService);
+  }
 
-        mockMvc.perform(post("/").param("notation", "notation"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("index"))
-                .andExpect(model().attribute("secret", "secret"))
-                .andExpect(model().attribute("configMap", config));
+  @Test
+  void fetchPopulatesModel() throws Exception {
+    Map<String, Object> config = Map.of("k", "v");
+    when(secretService.fetchSecret("notation")).thenReturn("secret");
+    when(secretService.getSpringConfig()).thenReturn(config);
 
-        verify(secretService).fetchSecret("notation");
-        verify(secretService).getSpringConfig();
-        verifyNoMoreInteractions(secretService);
-    }
+    mockMvc
+        .perform(post("/").param("notation", "notation"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("index"))
+        .andExpect(model().attribute("secret", "secret"))
+        .andExpect(model().attribute("configMap", config));
+
+    verify(secretService).fetchSecret("notation");
+    verify(secretService).getSpringConfig();
+    verifyNoMoreInteractions(secretService);
+  }
 }

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/AuditLoggingValidatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/AuditLoggingValidatorTest.java
@@ -2,43 +2,53 @@ package com.keepersecurity.spring.ksm.autoconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
+import com.keepersecurity.secretsManager.core.InMemoryStorage;
+import com.keepersecurity.secretsManager.core.KeyValueStorage;
 import java.util.Objects;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 class AuditLoggingValidatorTest {
 
   private final ApplicationContextRunner contextRunner =
-      new ApplicationContextRunner().withUserConfiguration(KeeperKsmAutoConfiguration.class)
-          .withPropertyValues("keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
-              "keeper.ksm.provider-type=sun_pkcs11", "keeper.ksm.hsm-provider=awsCloudHsm",
+      new ApplicationContextRunner()
+          .withUserConfiguration(KeeperKsmAutoConfiguration.class)
+          .withBean("ksmConfig", KeyValueStorage.class, () -> new InMemoryStorage("{}"))
+          .withPropertyValues(
+              "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
+              "keeper.ksm.provider-type=sun_pkcs11",
+              "keeper.ksm.hsm-provider=awsCloudHsm",
               "crypto.check.mode=warn");
 
   @Test
   void failsWithoutAuditSinkWhenIl5Enforced() {
-    contextRunner.withPropertyValues("keeper.ksm.enforce-il5=true")
+    contextRunner
+        .withPropertyValues("keeper.ksm.enforce-il5=true")
         .run(context -> assertThat(context).hasFailed());
   }
 
   @Test
   void warnsInsteadOfFailingWhenAuditModeWarn() {
-    contextRunner.withPropertyValues("keeper.ksm.enforce-il5=true", "audit.check.mode=warn")
+    contextRunner
+        .withPropertyValues("keeper.ksm.enforce-il5=true", "audit.check.mode=warn")
         .run(context -> assertThat(context).hasNotFailed());
   }
 
   @Test
   void passesWhenAuditLoggerHasFileSink() {
     configureLogging("logback-audit.xml");
-    contextRunner.withPropertyValues("keeper.ksm.enforce-il5=true")
+    contextRunner
+        .withPropertyValues("keeper.ksm.enforce-il5=true")
         .run(context -> assertThat(context).hasNotFailed());
   }
 
   @Test
   void failsWhenAuditLoggerBelowInfo() {
     configureLogging("logback-audit-debug.xml");
-    contextRunner.withPropertyValues("keeper.ksm.enforce-il5=true")
+    contextRunner
+        .withPropertyValues("keeper.ksm.enforce-il5=true")
         .run(context -> assertThat(context).hasFailed());
   }
 
@@ -48,8 +58,9 @@ class AuditLoggingValidatorTest {
     JoranConfigurator configurator = new JoranConfigurator();
     configurator.setContext(context);
     try {
-      configurator.doConfigure(Objects
-          .requireNonNull(Thread.currentThread().getContextClassLoader().getResource(resource)));
+      configurator.doConfigure(
+          Objects.requireNonNull(
+              Thread.currentThread().getContextClassLoader().getResource(resource)));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/ExplicitProviderTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/ExplicitProviderTest.java
@@ -1,16 +1,26 @@
 package com.keepersecurity.spring.ksm.autoconfig;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.keepersecurity.secretsManager.core.InMemoryStorage;
+import com.keepersecurity.secretsManager.core.KeyValueStorage;
+import java.security.Security;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 
-import java.security.Security;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-@SpringBootTest(classes = KeeperKsmAutoConfiguration.class,
+@SpringBootTest(
+    classes = {KeeperKsmAutoConfiguration.class, ExplicitProviderTest.Config.class},
     properties = {"keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json"})
 class ExplicitProviderTest {
+
+  static class Config {
+    @Bean
+    KeyValueStorage ksmConfig() {
+      return new InMemoryStorage("{}");
+    }
+  }
 
   @AfterEach
   void cleanup() {

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
@@ -2,6 +2,8 @@ package com.keepersecurity.spring.ksm.autoconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.keepersecurity.secretsManager.core.InMemoryStorage;
+import com.keepersecurity.secretsManager.core.KeyValueStorage;
 import java.security.Provider;
 import java.security.Security;
 import org.junit.jupiter.api.Test;
@@ -10,20 +12,26 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 class Il5ComplianceValidatorTest {
 
   private final ApplicationContextRunner contextRunner =
-      new ApplicationContextRunner().withUserConfiguration(KeeperKsmAutoConfiguration.class)
-          .withPropertyValues("keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
-              "keeper.ksm.provider-type=sun_pkcs11", "keeper.ksm.hsm-provider=awsCloudHsm",
+      new ApplicationContextRunner()
+          .withUserConfiguration(KeeperKsmAutoConfiguration.class)
+          .withBean("ksmConfig", KeyValueStorage.class, () -> new InMemoryStorage("{}"))
+          .withPropertyValues(
+              "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
+              "keeper.ksm.provider-type=sun_pkcs11",
+              "keeper.ksm.hsm-provider=awsCloudHsm",
               "audit.check.mode=warn");
 
   @Test
   void failsWithoutFipsProviderWhenIl5Enforced() {
-    contextRunner.withPropertyValues("keeper.ksm.enforce-il5=true")
+    contextRunner
+        .withPropertyValues("keeper.ksm.enforce-il5=true")
         .run(context -> assertThat(context).hasFailed());
   }
 
   @Test
   void warnsInsteadOfFailingWhenModeWarn() {
-    contextRunner.withPropertyValues("keeper.ksm.enforce-il5=true", "crypto.check.mode=warn")
+    contextRunner
+        .withPropertyValues("keeper.ksm.enforce-il5=true", "crypto.check.mode=warn")
         .run(context -> assertThat(context).hasNotFailed());
   }
 
@@ -31,7 +39,8 @@ class Il5ComplianceValidatorTest {
   void passesWhenFipsProviderActive() {
     try {
       Security.addProvider(new TestFipsProvider());
-      contextRunner.withPropertyValues("keeper.ksm.enforce-il5=true")
+      contextRunner
+          .withPropertyValues("keeper.ksm.enforce-il5=true")
           .run(context -> assertThat(context).hasNotFailed());
     } finally {
       Security.removeProvider("BCFIPS");
@@ -44,4 +53,3 @@ class Il5ComplianceValidatorTest {
     }
   }
 }
-

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfigurationTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfigurationTest.java
@@ -1,19 +1,32 @@
 package com.keepersecurity.spring.ksm.autoconfig;
 
-import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest(classes = KeeperKsmAutoConfiguration.class,
-    properties = {"keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json"})
+import com.keepersecurity.secretsManager.core.InMemoryStorage;
+import com.keepersecurity.secretsManager.core.KeyValueStorage;
+import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootTest(
+    classes = {KeeperKsmAutoConfiguration.class, KeeperKsmAutoConfigurationTest.Config.class})
 class KeeperKsmAutoConfigurationTest {
 
-  @Autowired
-  private SecretsManagerOptions options;
+  static class Config {
+    @Bean
+    KeyValueStorage ksmConfig() throws IOException {
+      String json = Files.readString(Path.of("src/test/resources/starter-ksm-config.json"));
+      return new InMemoryStorage(json);
+    }
+  }
+
+  @Autowired private SecretsManagerOptions options;
 
   @Test
   void contextLoads() {

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/ProviderSelectionTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/ProviderSelectionTest.java
@@ -1,17 +1,29 @@
 package com.keepersecurity.spring.ksm.autoconfig;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.keepersecurity.secretsManager.core.InMemoryStorage;
+import com.keepersecurity.secretsManager.core.KeyValueStorage;
+import java.security.Security;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 
-import java.security.Security;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-@SpringBootTest(classes = KeeperKsmAutoConfiguration.class,
-    properties = {"keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
-        "keeper.ksm.provider-class=com.keepersecurity.spring.ksm.autoconfig.TestBcProvider"})
+@SpringBootTest(
+    classes = {KeeperKsmAutoConfiguration.class, ProviderSelectionTest.Config.class},
+    properties = {
+      "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
+      "keeper.ksm.provider-class=com.keepersecurity.spring.ksm.autoconfig.TestBcProvider"
+    })
 class ProviderSelectionTest {
+
+  static class Config {
+    @Bean
+    KeyValueStorage ksmConfig() {
+      return new InMemoryStorage("{}");
+    }
+  }
 
   @AfterEach
   void cleanup() {
@@ -23,5 +35,4 @@ class ProviderSelectionTest {
     Security.addProvider(new TestBcProvider());
     assertNotNull(Security.getProvider("BC"), "BC provider should be registered");
   }
-
 }


### PR DESCRIPTION
## Summary
- drop SoftHSM2 auto-wiring and PKCS#11 config in KeeperKsmAutoConfiguration
- require a user-supplied `ksmConfig` bean for SecretsManagerOptions
- adjust tests and example app to provide the configuration bean

## Testing
- `./gradlew test`
- `cd examples/spring-boot && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_6894dd037bb4832f9a555a2a4a7bbe0f