### PR TITLE
feat: drop pkcs11 hsm providers

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KeeperKsmAutoConfiguration.java
@@ -181,10 +181,6 @@ public class KeeperKsmAutoConfiguration {
       case AWS -> AwsSaver.save(config, props);
       case AZURE -> AzureSaver.save(config, props);
       case GOOGLE -> GoogleSaver.save(config, props);
-      case AWS_HSM -> AwsHsmSaver.save(config, props);
-      case AZURE_HSM -> AzureHsmSaver.save(config, props);
-      case FORTANIX -> FortanixSaver.save(config, props);
-      case HSM, SOFTHSM2, SUN_PKCS11 -> HsmSaver.save(config, props);
     }
 
     log.atInfo().log("One-time token consumed.");
@@ -231,7 +227,6 @@ public class KeeperKsmAutoConfiguration {
           }
         };
       }
-      case HSM, AWS_HSM, AZURE_HSM, FORTANIX -> "PKCS11";
       default -> {
         String message = "Unsupported provider for keystore persistence: " + providerType;
         log.atWarn().log(message);
@@ -354,30 +349,6 @@ public class KeeperKsmAutoConfiguration {
         throw new IllegalStateException(
             "Failed to persist the KMS Config to Google Secret Manager", e);
       }
-    }
-  }
-
-  private static class HsmSaver {
-    static void save(ObjectNode config, KeeperKsmProperties props) {
-      saveConfigToKeystore(config, props);
-    }
-  }
-
-  private static class AwsHsmSaver {
-    static void save(ObjectNode config, KeeperKsmProperties props) {
-      HsmSaver.save(config, props);
-    }
-  }
-
-  private static class AzureHsmSaver {
-    static void save(ObjectNode config, KeeperKsmProperties props) {
-      HsmSaver.save(config, props);
-    }
-  }
-
-  private static class FortanixSaver {
-    static void save(ObjectNode config, KeeperKsmProperties props) {
-      HsmSaver.save(config, props);
     }
   }
 

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmConfigProvider.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/KsmConfigProvider.java
@@ -1,23 +1,11 @@
 package com.keepersecurity.spring.ksm.autoconfig;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 /**
  * Supported configuration providers for Keeper Secrets Manager.
  *
- * <p>
- * Each constant represents a mechanism for storing the KSM configuration along with the default
+ * <p>Each constant represents a mechanism for storing the KSM configuration along with the default
  * location for that configuration, the Impact Level readiness and the commercial compliance
  * profile.
- * </p>
- *
- * <p>
- * The {@link #SOFTHSM2} provider uses SoftHSM2 to emulate an IL5 hardware security module for local
- * development. When the {@code enforceIl5} property is enabled the emulator is rejected and an
- * {@link IllegalStateException} is thrown early in application start-up.
- * </p>
  */
 public enum KsmConfigProvider {
   /** Default keystore using the platform provider. */
@@ -28,57 +16,15 @@ public enum KsmConfigProvider {
   BC_FIPS("ksm-config.bcfks", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
   /** Keystore using the Oracle FIPS provider. */
   ORACLE_FIPS("ksm-config.p12", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
-  /**
-   * Uses the JVM's built-in SunPKCS11 provider.
-   * <p>
-   * The provider must be registered with a configuration file that references your HSM's PKCS#11
-   * library so the JDK can load the native module. See the {@code SUN_PKCS11.md} document for
-   * details on enabling the provider.
-   * </p>
-   */
-  /** Configuration stored in an HSM using the SunPKCS11 provider. */
-  SUN_PKCS11("pkcs11://slot/0/token/kms", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
-  /**
-   * Configuration stored in SoftHSM2 for local development. SoftHSM2 provides an emulator for
-   * IL5-capable HSMs but is not IL5 compliant. If {@code enforceIl5} is enabled this provider fails
-   * fast.
-   */
-  SOFTHSM2("pkcs11://slot/0/token/softhsm2", SecurityLevel.IL5, SecurityProfile.NONE) {
-    /**
-     * Creates a {@link PKCS11Config} pointing to the SoftHSM2 library.
-     *
-     * @param properties resolved Keeper configuration properties
-     * @return PKCS#11 configuration referencing SoftHSM2
-     * @throws IllegalStateException if IL5 enforcement is enabled or the SoftHSM2 library cannot be
-     *         located
-     */
-    @Override
-    public PKCS11Config createPkcs11Config(KeeperKsmProperties properties) {
-      if (properties != null && properties.isEnforceIl5()) {
-        throw new IllegalStateException(
-            "SoftHSM2 is not permitted when IL5 enforcement is enabled.");
-      }
-      Path library = detectSoftHsm2Library();
-      return new PKCS11Config(library.toString());
-    }
-  },
   /** Configuration stored in AWS Secrets Manager. */
   AWS("aws-secrets://region/resource", SecurityLevel.IL5, SecurityProfile.FEDRAMP_HIGH),
   /** Configuration stored in Azure Key Vault. */
   AZURE("azure-keyvault://vault/resource", SecurityLevel.IL5, SecurityProfile.FEDRAMP_HIGH),
-  /** Configuration stored in AWS CloudHSM. */
-  AWS_HSM("aws-cloudhsm://resource", SecurityLevel.IL5, SecurityProfile.FEDRAMP_HIGH),
-  /** Configuration stored in Azure Dedicated HSM. */
-  AZURE_HSM("azure-dedicatedhsm://resource", SecurityLevel.IL5, SecurityProfile.FEDRAMP_HIGH),
   /** Configuration stored in Google Secret Manager. */
-  GOOGLE("gcp-secretmanager://project/resource", SecurityLevel.IL4,
-      SecurityProfile.FEDRAMP_MODERATE),
-  /** Configuration stored in a Fortanix DSM. */
-  FORTANIX("fortanix://token", SecurityLevel.IL5, SecurityProfile.FIPS_140_2),
+  GOOGLE(
+      "gcp-secretmanager://project/resource", SecurityLevel.IL4, SecurityProfile.FEDRAMP_MODERATE),
   /** Raw JSON configuration on the filesystem. */
-  RAW("ksm-config.json", SecurityLevel.IL2, SecurityProfile.NONE),
-  /** Generic PKCS#11 HSM configuration. */
-  HSM("pkcs11://slot/0/token/kms", SecurityLevel.IL5, SecurityProfile.FIPS_140_2);
+  RAW("ksm-config.json", SecurityLevel.IL2, SecurityProfile.NONE);
 
   private final String defaultLocation;
   private final SecurityLevel ilLevel;
@@ -91,8 +37,8 @@ public enum KsmConfigProvider {
    * @param ilLevel the Impact Level associated with the provider
    * @param commercialProfile the commercial compliance profile
    */
-  KsmConfigProvider(String defaultLocation, SecurityLevel ilLevel,
-      SecurityProfile commercialProfile) {
+  KsmConfigProvider(
+      String defaultLocation, SecurityLevel ilLevel, SecurityProfile commercialProfile) {
     if (isKeystoreBased()) {
       this.defaultLocation = KsmKeystoreDefaults.getDefaultKeystoreFilename();
     } else {
@@ -166,16 +112,6 @@ public enum KsmConfigProvider {
   }
 
   /**
-   * Determines if the configuration is stored in an HSM.
-   *
-   * @return {@code true} if the provider uses an HSM backend
-   */
-  public boolean isHsm() {
-    return this == HSM || this == SUN_PKCS11 || this == SOFTHSM2 || this == AWS_HSM
-        || this == AZURE_HSM || this == FORTANIX;
-  }
-
-  /**
    * Indicates whether the provider meets the FedRAMP High profile.
    *
    * @return {@code true} if FedRAMP High compliant
@@ -183,46 +119,9 @@ public enum KsmConfigProvider {
   public boolean isFedRAMPHigh() {
     return commercialProfile == SecurityProfile.FEDRAMP_HIGH;
   }
-
-  /**
-   * Creates a PKCS#11 configuration for providers that require one.
-   *
-   * @param properties the resolved properties
-   * @return configuration describing the native library
-   * @throws UnsupportedOperationException if the provider does not support PKCS#11 configuration
-   */
-  public PKCS11Config createPkcs11Config(KeeperKsmProperties properties) {
-    throw new UnsupportedOperationException("PKCS11Config not supported for " + this);
-  }
-
-  /**
-   * Attempts to locate the SoftHSM2 PKCS#11 library using common installation paths.
-   *
-   * @return path to the SoftHSM2 native library
-   * @throws IllegalStateException if the library cannot be found or is unreadable
-   */
-  private static Path detectSoftHsm2Library() {
-    Path macOs = Paths.get("/opt/homebrew/lib/softhsm/libsofthsm2.so");
-    if (Files.isReadable(macOs)) {
-      return macOs;
-    }
-    Path linuxUsr = Paths.get("/usr/lib/softhsm/libsofthsm2.so");
-    if (Files.isReadable(linuxUsr)) {
-      return linuxUsr;
-    }
-    Path linuxUsrLocal = Paths.get("/usr/local/lib/softhsm/libsofthsm2.so");
-    if (Files.isReadable(linuxUsrLocal)) {
-      return linuxUsrLocal;
-    }
-    throw new IllegalStateException(
-        "SoftHSM2 PKCS#11 library not found or unreadable at /opt/homebrew/lib/softhsm/libsofthsm2.so, /usr/lib/softhsm/libsofthsm2.so, or /usr/local/lib/softhsm/libsofthsm2.so");
-  }
 }
 
-
-/**
- * Impact Level readiness of a provider.
- */
+/** Impact Level readiness of a provider. */
 enum SecurityLevel {
   /** Suitable for IL2 workloads. */
   IL2,
@@ -234,10 +133,7 @@ enum SecurityLevel {
   IL6
 }
 
-
-/**
- * Commercial compliance profile of a provider.
- */
+/** Commercial compliance profile of a provider. */
 enum SecurityProfile {
   /** No specific compliance guarantees. */
   NONE,

--- a/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/PKCS11Config.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/main/java/com/keepersecurity/spring/ksm/autoconfig/PKCS11Config.java
@@ -1,8 +1,0 @@
-package com.keepersecurity.spring.ksm.autoconfig;
-
-/**
- * Simple representation of a PKCS#11 configuration.
- *
- * @param libraryPath path to the native PKCS#11 library
- */
-public record PKCS11Config(String libraryPath) {}

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/AuditLoggingValidatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/AuditLoggingValidatorTest.java
@@ -18,7 +18,7 @@ class AuditLoggingValidatorTest {
           .withBean("ksmConfig", KeyValueStorage.class, () -> new InMemoryStorage("{}"))
           .withPropertyValues(
               "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
-              "keeper.ksm.provider-type=sun_pkcs11",
+              "keeper.ksm.provider-type=bc_fips",
               "crypto.check.mode=warn");
 
   @Test

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5ComplianceValidatorTest.java
@@ -17,7 +17,7 @@ class Il5ComplianceValidatorTest {
           .withBean("ksmConfig", KeyValueStorage.class, () -> new InMemoryStorage("{}"))
           .withPropertyValues(
               "keeper.ksm.secret-path=src/test/resources/starter-ksm-config.json",
-              "keeper.ksm.provider-type=sun_pkcs11",
+              "keeper.ksm.provider-type=bc_fips",
               "audit.check.mode=warn");
 
   @Test

--- a/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
+++ b/integration/spring-boot-starter-keeper-ksm/src/test/java/com/keepersecurity/spring/ksm/autoconfig/Il5EnforcementTest.java
@@ -28,11 +28,11 @@ class Il5EnforcementTest {
   }
 
   @Test
-  void sunPkcs11AllowedWithIl5Enforcement() {
+  void bcFipsAllowedWithIl5Enforcement() {
     try {
       Security.addProvider(new TestFipsProvider());
       contextRunner
-          .withPropertyValues("keeper.ksm.enforce-il5=true", "keeper.ksm.provider-type=sun_pkcs11")
+          .withPropertyValues("keeper.ksm.enforce-il5=true", "keeper.ksm.provider-type=bc_fips")
           .run(context -> org.assertj.core.api.Assertions.assertThat(context).hasNotFailed());
     } finally {
       Security.removeProvider("BCFIPS");
@@ -44,7 +44,7 @@ class Il5EnforcementTest {
     contextRunner
         .withPropertyValues(
             "keeper.ksm.enforce-il5=true",
-            "keeper.ksm.provider-type=sun_pkcs11",
+            "keeper.ksm.provider-type=bc_fips",
             "keeper.ksm.one-time-token=dummy.txt",
             "crypto.check.mode=warn")
         .run(context -> org.assertj.core.api.Assertions.assertThat(context).hasFailed());
@@ -55,7 +55,7 @@ class Il5EnforcementTest {
     contextRunner
         .withPropertyValues(
             "keeper.ksm.enforce-il5=true",
-            "keeper.ksm.provider-type=sun_pkcs11",
+            "keeper.ksm.provider-type=bc_fips",
             "bootstrap.check.mode=warn",
             "crypto.check.mode=warn",
             "ksm.config.ott-token=dummy")


### PR DESCRIPTION
## Summary
- remove PKCS#11/HSM providers and related configuration helpers
- simplify auto-configuration and tests to reflect remaining providers

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_6894f7a5d758832f8aee9ab84a4a49c6