### PR TITLE
docs: update PKCS#11 guidance

### DIFF
--- a/integration/spring-boot-starter-keeper-ksm/HOW_TO/SOFTHSM2.md
+++ b/integration/spring-boot-starter-keeper-ksm/HOW_TO/SOFTHSM2.md
@@ -21,8 +21,7 @@ softhsm2-util --init-token --slot 0 --label ksm-token
 Make note of the slot number (`0` in this example), the token label (`ksm-token`), and the PIN you chose. These values are needed when configuring your application.
 
 ## Configure the provider
-1. Ensure the `SOFTHSM2_CONF` environment variable points to your configuration file if you are not using the default location.
-2. Add the token details to your Spring configuration:
+1. Add the token details to your Spring configuration:
    ```yaml
    keeper:
      ksm:
@@ -30,7 +29,11 @@ Make note of the slot number (`0` in this example), the token label (`ksm-token`
        secret-path: pkcs11://slot/0/token/ksm-token   # use your slot and label
        secret-password: <PIN>                         # token PIN
    ```
-3. Start the application and enter the PIN when prompted.
+2. Start the application and enter the PIN when prompted.
+
+For advanced scenarios or custom PKCS#11 providers, define a dedicated
+`@Configuration` class that registers the provider and supplies the
+`SecretsManagerOptions` bean as shown in the main README.
 
 SoftHSM2 should only be used for local development. For production deployments use a hardware security module that meets your security requirements.
 

--- a/integration/spring-boot-starter-keeper-ksm/SUN_PKCS11.md
+++ b/integration/spring-boot-starter-keeper-ksm/SUN_PKCS11.md
@@ -2,7 +2,7 @@
 
 The `SUN_PKCS11` option uses the JDK's built‑in SunPKCS11 security provider. This
 provider is disabled by default and must be loaded with a configuration file that
-points to your HSM's PKCS#11 library.
+points to the PKCS#11 module supplied by your HSM vendor.
 
 1. Enable the provider's module so it can be discovered at runtime. Add the
    `jdk.crypto.cryptoki` module to the JVM:
@@ -23,12 +23,16 @@ points to your HSM's PKCS#11 library.
    security.provider.9=SunPKCS11 /path/to/pkcs11.cfg
    ```
    or load it programmatically:
-   ```java
-   Security.addProvider(new SunPKCS11("/path/to/pkcs11.cfg"));
-   ```
+ ```java
+  Security.addProvider(new SunPKCS11("/path/to/pkcs11.cfg"));
+  ```
 
 ## Why Enable It?
 
 Keeper uses the provider to store the configuration on the HSM when the
 `SUN_PKCS11` profile is selected. Without registering the provider the starter
 cannot access the PKCS#11 token and initialization will fail.
+
+After registering the provider, create a custom `@Configuration` class that
+exposes a `SecretsManagerOptions` bean using a PKCS#11-backed storage to connect
+the Spring Boot starter with your HSM.


### PR DESCRIPTION
## Summary
- remove obsolete hsm-provider and pkcs11-library references
- clarify SoftHSM2 troubleshooting and add PKCS#11 configuration guidance
- document custom @Configuration approach for PKCS#11/HSM usage

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_689506668ab8832f9e0d0e0ab2e4790a